### PR TITLE
refactor(auth) : integrate auth context into layout and header

### DIFF
--- a/app/Controller/HomeController.php
+++ b/app/Controller/HomeController.php
@@ -3,8 +3,12 @@
 namespace App\Controller;
 
 use App\Core\Contract\FlashInterface;
+use App\Core\FormId;
 use App\Core\View;
+use App\Http\Request;
 use App\Model\Contract\UserModelInterface;
+use App\Security\Contract\AuthCheckerInterface;
+use App\Security\Contract\CsrfTokenInterface;
 
 class HomeController extends BaseController
 {
@@ -15,8 +19,14 @@ class HomeController extends BaseController
      *
      * @param UserModelInterface $userModel The model used to interact with user data.
      */
-    public function __construct(View $view, private UserModelInterface $userModel, FlashInterface $flash)
-    {
+    public function __construct(
+        View $view,
+        private UserModelInterface $userModel,
+        FlashInterface $flash,
+        private Request $request,
+        private AuthCheckerInterface $authChecker,
+        private CsrfTokenInterface $csrf,
+    ) {
         parent::__construct($view, $flash);
     }
 
@@ -32,10 +42,15 @@ class HomeController extends BaseController
     {
         $users = $this->userModel->findAll();
 
+        $isAuthenticated = $this->authChecker->isAuthenticated($this->request);
+
         $this->render('home/index.html.twig', $this->withFlashes([
-            'title'   => 'Home',
-            'message' => 'This is the home page.',
-            'users'   => $users,
+            'show_header'       => true,
+            'is_authenticated'  => $isAuthenticated,
+            'logout_csrf_token' => $isAuthenticated ? $this->csrf->generateToken(FormId::LOGOUT) : '',
+            'title'             => 'Home',
+            'message'           => 'This is the home page.',
+            'users'             => $users,
         ]));
     }
 }

--- a/app/Core/Container/Provider/ControllerServiceProvider.php
+++ b/app/Core/Container/Provider/ControllerServiceProvider.php
@@ -32,6 +32,7 @@ use App\Handler\Auth\ResetPasswordGetHandler;
 use App\Handler\Auth\ResetPasswordPostHandler;
 use App\Http\Request;
 use App\Model\Contract\UserModelInterface;
+use App\Security\Contract\AuthCheckerInterface;
 use App\Security\Contract\CsrfTokenInterface;
 use Psr\Container\ContainerInterface;
 
@@ -77,7 +78,16 @@ final class ControllerServiceProvider
                 /** @var FlashInterface $flash */
                 $flash = $container->get(FlashInterface::class);
 
-                return new HomeController($view, $userModel, $flash);
+                /** @var Request $request */
+                $request = $container->get(Request::class);
+
+                /** @var AuthCheckerInterface $authChecker */
+                $authChecker = $container->get(AuthCheckerInterface::class);
+
+                /** @var CsrfTokenInterface $csrf */
+                $csrf = $container->get(CsrfTokenInterface::class);
+
+                return new HomeController($view, $userModel, $flash, $request, $authChecker, $csrf);
             },
 
             ErrorController::class => static function (ContainerInterface $container): ErrorController {

--- a/app/Security/CsrfTokenManager.php
+++ b/app/Security/CsrfTokenManager.php
@@ -56,10 +56,16 @@ final class CsrfTokenManager implements CsrfTokenInterface
         /** @var array<string,mixed> $bag */
         $bag = is_array($raw) ? $raw : [];
 
+        $existing = $bag[$formId] ?? null;
+        if (is_string($existing) && $existing !== '') {
+            return $existing;
+        }
+
         $token        = bin2hex(random_bytes(32));
         $bag[$formId] = $token;
 
         $this->session->set(self::BAG, $bag);
+
         return $token;
     }
 

--- a/app/Views/templates/layouts/base.html.twig
+++ b/app/Views/templates/layouts/base.html.twig
@@ -25,7 +25,9 @@
 		</style>
 	</head>
 	<body>
-		{% include 'templates/partials/header.html.twig' %}
+		{% if show_header ?? false %}
+			{% include 'templates/partials/header.html.twig' %}
+		{% endif %}
 
 		<main>
 			{% block content %}{% endblock %}

--- a/app/Views/templates/partials/header.html.twig
+++ b/app/Views/templates/partials/header.html.twig
@@ -4,10 +4,15 @@
         <a href="{{ base_path }}">Home page</a>
 
         {% if is_authenticated %}
+            <a href="/coding-blog/account">Mon compte</a>
+
             <form method="post" action="/coding-blog/logout" style="display:inline;">
                 <input type="hidden" name="csrf_token" value="{{ logout_csrf_token }}">
                 <button type="submit">Déconnexion</button>
             </form>
+        {% else %}
+            <a href="/coding-blog/login">Login</a>
+            <a href="/coding-blog/register">Register</a>
         {% endif %}
     </nav>
 </header>

--- a/tests/Unit/Controller/HomeControllerTest.php
+++ b/tests/Unit/Controller/HomeControllerTest.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-// tests/Unit/Controller/HomeControllerTest.php
-
 namespace Tests\Unit\Controller;
 
 use App\Controller\HomeController;
 use App\Core\FlashService;
 use App\Core\SessionManager;
 use App\Core\View;
+use App\Http\Request;
 use App\Model\Entity\UserEntity;
 use App\Model\UserModel;
+use App\Security\Contract\AuthCheckerInterface;
+use App\Security\Contract\CsrfTokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -22,18 +23,25 @@ use PHPUnit\Framework\TestCase;
 final class TestableHomeController extends HomeController
 {
     public ?string $lastTemplate = null;
+
     /** @var array<string,mixed> */
     public array $lastParams = [];
-    public function __construct(View $view, UserModel $userModel, FlashService $flash)
-    {
-        parent::__construct($view, $userModel, $flash);
+
+    public function __construct(
+        View $view,
+        UserModel $userModel,
+        FlashService $flash,
+        Request $request,
+        AuthCheckerInterface $authChecker,
+        CsrfTokenInterface $csrf,
+    ) {
+        parent::__construct($view, $userModel, $flash, $request, $authChecker, $csrf);
     }
 
     protected function render(string $template, array $params = []): void
     {
         $this->lastTemplate = $template;
         $this->lastParams   = $params;
-        // pas d'echo
     }
 }
 
@@ -41,7 +49,6 @@ final class HomeControllerTest extends TestCase
 {
     private function makeView(): View
     {
-        // View factice : ne sera pas appelée (render est surchargée)
         return new class () extends View {
             public function render(string $template, array $params = []): string
             {
@@ -55,67 +62,176 @@ final class HomeControllerTest extends TestCase
         return new FlashService(new SessionManager());
     }
 
-    /** @return UserModel&MockObject */
+    private function makeRequest(): Request
+    {
+        return $this->createMock(Request::class);
+    }
+
+    /**
+     * @return UserModel&MockObject
+     */
     private function mockUserModel(): UserModel
     {
         /** @var UserModel&MockObject $m */
         $m = $this->createMock(UserModel::class);
+
+        return $m;
+    }
+
+    /**
+     * @return AuthCheckerInterface&MockObject
+     */
+    private function mockAuthChecker(): AuthCheckerInterface
+    {
+        /** @var AuthCheckerInterface&MockObject $m */
+        $m = $this->createMock(AuthCheckerInterface::class);
+
+        return $m;
+    }
+
+    /**
+     * @return CsrfTokenInterface&MockObject
+     */
+    private function mockCsrf(): CsrfTokenInterface
+    {
+        /** @var CsrfTokenInterface&MockObject $m */
+        $m = $this->createMock(CsrfTokenInterface::class);
+
         return $m;
     }
 
     public function testIndexRendersHomeTemplateWithUsersAndStaticData(): void
     {
-        $view  = $this->makeView();
-        $flash = $this->makeFlash();
+        $view        = $this->makeView();
+        $flash       = $this->makeFlash();
+        $request     = $this->makeRequest();
+        $authChecker = $this->mockAuthChecker();
+        $csrf        = $this->mockCsrf();
+
         $users = [
             (new UserEntity())->setUserId(1)->setUsername('Alice')->setEmail('a@example.test'),
             (new UserEntity())->setUserId(2)->setUsername('Bob')->setEmail('b@example.test'),
         ];
+
         $userModel = $this->mockUserModel();
         $userModel->expects($this->once())
             ->method('findAll')
             ->willReturn($users);
-        $ctrl = new TestableHomeController($view, $userModel, $flash);
+
+        $authChecker->expects($this->once())
+            ->method('isAuthenticated')
+            ->with($request)
+            ->willReturn(false);
+
+        $csrf->expects($this->never())
+            ->method('generateToken');
+
+        $ctrl = new TestableHomeController(
+            $view,
+            $userModel,
+            $flash,
+            $request,
+            $authChecker,
+            $csrf
+        );
+
         $ctrl->index();
-        // Vérifie le template
+
         self::assertSame('home/index.html.twig', $ctrl->lastTemplate);
-        // Vérifie les données principales
         self::assertArrayHasKey('title', $ctrl->lastParams);
         self::assertArrayHasKey('message', $ctrl->lastParams);
         self::assertArrayHasKey('users', $ctrl->lastParams);
+        self::assertArrayHasKey('show_header', $ctrl->lastParams);
+        self::assertArrayHasKey('is_authenticated', $ctrl->lastParams);
+        self::assertArrayHasKey('logout_csrf_token', $ctrl->lastParams);
+
         self::assertSame('Home', $ctrl->lastParams['title']);
         self::assertSame('This is the home page.', $ctrl->lastParams['message']);
         self::assertSame($users, $ctrl->lastParams['users']);
-        // Les flashes sont ajoutées par withFlashes()
+        self::assertTrue($ctrl->lastParams['show_header']);
+        self::assertFalse($ctrl->lastParams['is_authenticated']);
+        self::assertSame('', $ctrl->lastParams['logout_csrf_token']);
+
         self::assertArrayHasKey('flashes', $ctrl->lastParams);
         self::assertIsArray($ctrl->lastParams['flashes']);
     }
 
     public function testIndexMergesFlashesIntoRenderedData(): void
     {
-        $view  = $this->makeView();
-        $flash = $this->makeFlash();
-        // Ajoute une flash pour vérifier qu’elle est bien consommée et transmise
+        $view        = $this->makeView();
+        $flash       = $this->makeFlash();
+        $request     = $this->makeRequest();
+        $authChecker = $this->mockAuthChecker();
+        $csrf        = $this->mockCsrf();
+
         $flash->add('error', 'Oops');
+
         $userModel = $this->mockUserModel();
         $userModel->method('findAll')->willReturn([]);
-        $ctrl = new TestableHomeController($view, $userModel, $flash);
+
+        $authChecker->expects($this->once())
+            ->method('isAuthenticated')
+            ->with($request)
+            ->willReturn(false);
+
+        $csrf->expects($this->never())
+            ->method('generateToken');
+
+        $ctrl = new TestableHomeController(
+            $view,
+            $userModel,
+            $flash,
+            $request,
+            $authChecker,
+            $csrf
+        );
+
         $ctrl->index();
+
         self::assertSame('home/index.html.twig', $ctrl->lastTemplate);
         self::assertArrayHasKey('flashes', $ctrl->lastParams);
         self::assertIsArray($ctrl->lastParams['flashes']);
 
-        /** @var array{
-         *   error:   list<string>,
-         *   success: list<string>,
-         *   warning: list<string>,
-         *   info:    list<string>,
-         *   notice:  list<string>
-         * } $flashes
-         */
+        /** @var array<string, list<string>> $flashes */
         $flashes = $ctrl->lastParams['flashes'];
 
         self::assertArrayHasKey('error', $flashes);
         self::assertGreaterThanOrEqual(1, \count($flashes['error']));
+    }
+
+    public function testIndexAddsLogoutTokenWhenUserIsAuthenticated(): void
+    {
+        $view        = $this->makeView();
+        $flash       = $this->makeFlash();
+        $request     = $this->makeRequest();
+        $authChecker = $this->mockAuthChecker();
+        $csrf        = $this->mockCsrf();
+
+        $userModel = $this->mockUserModel();
+        $userModel->method('findAll')->willReturn([]);
+
+        $authChecker->expects($this->once())
+            ->method('isAuthenticated')
+            ->with($request)
+            ->willReturn(true);
+
+        $csrf->expects($this->once())
+            ->method('generateToken')
+            ->with(\App\Core\FormId::LOGOUT)
+            ->willReturn('logout-token-123');
+
+        $ctrl = new TestableHomeController(
+            $view,
+            $userModel,
+            $flash,
+            $request,
+            $authChecker,
+            $csrf
+        );
+
+        $ctrl->index();
+
+        self::assertTrue($ctrl->lastParams['is_authenticated']);
+        self::assertSame('logout-token-123', $ctrl->lastParams['logout_csrf_token']);
     }
 }

--- a/tests/Unit/Core/Container/ControllerServiceProviderTest.php
+++ b/tests/Unit/Core/Container/ControllerServiceProviderTest.php
@@ -33,6 +33,7 @@ use App\Handler\Auth\ResetPasswordGetHandler;
 use App\Handler\Auth\ResetPasswordPostHandler;
 use App\Http\Request;
 use App\Model\Contract\UserModelInterface;
+use App\Security\Contract\AuthCheckerInterface;
 use App\Security\Contract\CsrfTokenInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -78,8 +79,9 @@ final class ControllerServiceProviderTest extends TestCase
             FlashInterface::class                => $this->createMock(FlashInterface::class),
             SessionInterface::class              => $this->createMock(SessionInterface::class),
             UserModelInterface::class            => $this->createMock(UserModelInterface::class),
-            CsrfTokenInterface::class            => $this->createMock(CsrfTokenInterface::class),
             Request::class                       => $this->createMock(Request::class),
+            AuthCheckerInterface::class          => $this->createMock(AuthCheckerInterface::class),
+            CsrfTokenInterface::class            => $this->createMock(CsrfTokenInterface::class),
 
             ConfirmAccountHandler::class         => $this->instantiateWithoutConstructor(ConfirmAccountHandler::class),
             RegisterGetHandler::class            => $this->instantiateWithoutConstructor(RegisterGetHandler::class),


### PR DESCRIPTION
## What does this pull request do?

  - [ ] Adds a feature
  - [ ] Fixes a bug
  - [X] Refactors existing code
  - [ ] Other (describe):

## Description

This pull request refactors the authentication display logic by integrating the auth context into the layout and header.
Previously, authentication-related UI (login, account, logout) was partially handled in specific pages (e.g. account page).
This change moves the logout action into the header and enables dynamic rendering based on the authentication state.
The auth context is currently exposed from the HomeController, allowing the layout to display different UI elements depending on whether the user is authenticated.
CSRF protection has been integrated into the logout flow to ensure secure form submission.
This refactor improves UI consistency and prepares the codebase for future global centralization of the authentication context (e.g. via Responder or middleware).

## Related issue

Closes #23

## Checklist

  - [X] Code runs without error
  - [X] Tests added or updated
  - [X] Coding style respected
  - [X] Issue linked (if applicable)
