### PR TITLE
feat(auth) : implement secure remember me authentication

### DIFF
--- a/app/Core/Container/Provider/AuthServiceProvider.php
+++ b/app/Core/Container/Provider/AuthServiceProvider.php
@@ -22,6 +22,7 @@ use App\Http\Contract\ResponderInterface;
 use App\Log\LogContextNormalizer;
 use App\Security\Contract\CsrfTokenInterface;
 use App\Security\Contract\HoneypotValidatorInterface;
+use App\Security\Contract\RememberMeCookieManagerInterface;
 use App\Security\Contract\SubmissionDelayValidatorInterface;
 use App\Security\Contract\TurnstileValidatorInterface;
 use App\Security\Guard\Contract\HoneypotGuardInterface;
@@ -349,6 +350,8 @@ final class AuthServiceProvider
                 $submissionDelayGuard = $container->get(SubmissionDelayGuardInterface::class);
                 /** @var RateLimitGuardInterface $rateLimitGuard */
                 $rateLimitGuard = $container->get(RateLimitGuardInterface::class);
+                /** @var RememberMeCookieManagerInterface $rememberMe */
+                $rememberMe = $container->get(RememberMeCookieManagerInterface::class);
 
                 return new LoginPostHandler(
                     $securityService,
@@ -357,6 +360,7 @@ final class AuthServiceProvider
                     $honeypotGuard,
                     $submissionDelayGuard,
                     $rateLimitGuard,
+                    $rememberMe,
                 );
             },
         ];
@@ -496,11 +500,14 @@ final class AuthServiceProvider
                 $flash = $container->get(FlashInterface::class);
                 /** @var ResponderInterface $responder */
                 $responder = $container->get(ResponderInterface::class);
+                /** @var RememberMeCookieManagerInterface $rememberMeManager */
+                $rememberMeManager = $container->get(RememberMeCookieManagerInterface::class);
 
                 return new LogoutHandler(
                     $securityService,
                     $flash,
                     $responder,
+                    $rememberMeManager,
                 );
             },
         ];

--- a/app/Core/Container/Provider/SystemServiceProvider.php
+++ b/app/Core/Container/Provider/SystemServiceProvider.php
@@ -25,19 +25,25 @@ use App\Infrastructure\Mail\MailjetMailer;
 use App\Log\LogContextNormalizer;
 use App\Middleware\AuthenticationMiddleware;
 use App\Middleware\CsrfMiddleware;
+use App\Middleware\RememberMeMiddleware;
 use App\Middleware\SecurityHeadersMiddleware;
+use App\Model\Contract\UserTokenModelInterface;
 use App\Security\Contract\AuthCheckerInterface;
 use App\Security\Contract\CsrfTokenInterface;
 use App\Security\Contract\HoneypotValidatorInterface;
+use App\Security\Contract\RememberMeCookieManagerInterface;
 use App\Security\Contract\SubmissionDelayValidatorInterface;
 use App\Security\Contract\TokenGeneratorInterface;
 use App\Security\Contract\TurnstileValidatorInterface;
 use App\Security\CsrfTokenManager;
 use App\Security\HoneypotValidator;
+use App\Security\RememberMeCookieManager;
 use App\Security\SessionAuthChecker;
 use App\Security\SubmissionDelayValidator;
 use App\Security\TokenGenerator;
 use App\Security\TurnstileValidator;
+use App\Service\Security\Contract\RememberMeServiceInterface;
+use App\Service\Security\RememberMeService;
 use App\Support\ErrorListNormalizer;
 use App\Validation\Contract\FormValidatorInterface;
 use App\Validation\FormValidator;
@@ -270,6 +276,21 @@ final class SystemServiceProvider
                 $session = $container->get(SessionInterface::class);
                 return new SessionAuthChecker($session);
             },
+
+            RememberMeCookieManager::class => static fn (): RememberMeCookieManager => new RememberMeCookieManager(),
+
+            RememberMeService::class => static function (ContainerInterface $container): RememberMeService {
+                /** @var UserTokenModelInterface $userTokenModel */
+                $userTokenModel = $container->get(UserTokenModelInterface::class);
+
+                /** @var TokenGeneratorInterface $tokenGenerator */
+                $tokenGenerator = $container->get(TokenGeneratorInterface::class);
+
+                /** @var SessionInterface $session */
+                $session = $container->get(SessionInterface::class);
+
+                return new RememberMeService($userTokenModel, $tokenGenerator, $session);
+            },
         ];
     }
 
@@ -316,6 +337,18 @@ final class SystemServiceProvider
                 $ts = $container->get(TurnstileValidator::class);
                 return $ts;
             },
+
+            RememberMeCookieManagerInterface::class => static function (ContainerInterface $container): RememberMeCookieManagerInterface {
+                /** @var RememberMeCookieManager $manager */
+                $manager = $container->get(RememberMeCookieManager::class);
+                return $manager;
+            },
+
+            RememberMeServiceInterface::class => static function (ContainerInterface $container): RememberMeServiceInterface {
+                /** @var RememberMeService $service */
+                $service = $container->get(RememberMeService::class);
+                return $service;
+            },
         ];
     }
 
@@ -327,6 +360,19 @@ final class SystemServiceProvider
     private static function getSecurityMiddlewares(): array
     {
         return [
+            RememberMeMiddleware::class => static function (ContainerInterface $container): RememberMeMiddleware {
+                /** @var AuthCheckerInterface $auth */
+                $auth = $container->get(AuthCheckerInterface::class);
+
+                /** @var RememberMeCookieManagerInterface $cookieManager */
+                $cookieManager = $container->get(RememberMeCookieManagerInterface::class);
+
+                /** @var RememberMeServiceInterface $rememberMe */
+                $rememberMe = $container->get(RememberMeServiceInterface::class);
+
+                return new RememberMeMiddleware($auth, $cookieManager, $rememberMe);
+            },
+
             AuthenticationMiddleware::class => static function (ContainerInterface $container): AuthenticationMiddleware {
                 /** @var AuthCheckerInterface $auth */
                 $auth = $container->get(AuthCheckerInterface::class);

--- a/app/Core/Container/Provider/UserServiceProvider.php
+++ b/app/Core/Container/Provider/UserServiceProvider.php
@@ -23,6 +23,7 @@ use App\Service\Security\ConfirmationResendService;
 use App\Service\Security\Contract\ForgotPasswordServiceInterface;
 use App\Service\Security\Contract\LoginServiceInterface;
 use App\Service\Security\Contract\LogoutServiceInterface;
+use App\Service\Security\Contract\RememberMeServiceInterface;
 use App\Service\Security\Contract\ResetPasswordServiceInterface;
 use App\Service\Security\Contract\SecurityServiceInterface;
 use App\Service\Security\ForgotPasswordService;
@@ -175,7 +176,10 @@ final class UserServiceProvider
                 /** @var SessionInterface $session */
                 $session = $container->get(SessionInterface::class);
 
-                return new LogoutService($session);
+                /** @var RememberMeServiceInterface $rememberMeService */
+                $rememberMeService = $container->get(RememberMeServiceInterface::class);
+
+                return new LogoutService($session, $rememberMeService);
             },
         ];
     }
@@ -294,15 +298,21 @@ final class UserServiceProvider
             LoginService::class => static function (ContainerInterface $container): LoginService {
                 /** @var FormValidatorInterface $validator */
                 $validator = $container->get(FormValidatorInterface::class);
+
                 /** @var UserModelInterface $userModel */
                 $userModel = $container->get(UserModelInterface::class);
+
                 /** @var SessionInterface $session */
                 $session = $container->get(SessionInterface::class);
+
+                /** @var RememberMeServiceInterface $rememberMe */
+                $rememberMe = $container->get(RememberMeServiceInterface::class);
 
                 return new LoginService(
                     $validator,
                     $userModel,
                     $session,
+                    $rememberMe,
                 );
             },
         ];

--- a/app/Handler/Auth/LoginPostHandler.php
+++ b/app/Handler/Auth/LoginPostHandler.php
@@ -8,6 +8,7 @@ use App\Core\Contract\FlashInterface;
 use App\Core\ErrorCode;
 use App\Core\MessageManager;
 use App\Http\Contract\ResponderInterface;
+use App\Security\Contract\RememberMeCookieManagerInterface;
 use App\Security\Guard\Contract\HoneypotGuardInterface;
 use App\Security\Guard\Contract\RateLimitGuardInterface;
 use App\Security\Guard\Contract\SubmissionDelayGuardInterface;
@@ -28,6 +29,7 @@ final class LoginPostHandler
         private HoneypotGuardInterface $honeypotGuard,
         private SubmissionDelayGuardInterface $submissionDelayGuard,
         private RateLimitGuardInterface $rateLimitGuard,
+        private RememberMeCookieManagerInterface $rememberMeManager,
     ) {
     }
 
@@ -36,8 +38,8 @@ final class LoginPostHandler
      */
     public function handle(array $form): void
     {
-        $email   = $this->strOrEmpty($form['email'] ?? null);
-        $context = $this->makeContext($email);
+        $identifier = $this->strOrEmpty($form['identifier'] ?? null);
+        $context    = $this->makeContext($identifier);
 
         /** @var array{
          *   form: array<string, mixed>,
@@ -109,7 +111,7 @@ final class LoginPostHandler
             'redirect'      => self::REDIRECT,
             'route_for_log' => '/login',
             'flash_type'    => 'error',
-            'put_old'       => ['email' => $email],
+            'put_old'       => ['identifier' => $identifier],
             'log_ctx'       => $context,
         ], $this->turnstileStepUp());
 
@@ -121,21 +123,22 @@ final class LoginPostHandler
         $result = $this->securityService->login($form);
 
         if (!empty($result['ok'])) {
+            $this->handleRememberMe($result);
             $this->replySuccess();
             return;
         }
 
-        $this->replyFailure($result, $email);
+        $this->replyFailure($result, $identifier, $form);
     }
 
     /**
      * @return array<string, mixed>
      */
-    private function makeContext(string $email): array
+    private function makeContext(string $identifier): array
     {
         return [
-            'form'  => self::FORM_ID,
-            'email' => $email !== '' ? $email : null,
+            'form'       => self::FORM_ID,
+            'identifier' => $identifier !== '' ? $identifier : null,
         ];
     }
 
@@ -162,11 +165,12 @@ final class LoginPostHandler
 
     /**
      * @param array<string, mixed> $result
+     * @param array<string, mixed> $form
      */
-    private function replyFailure(array $result, string $email): void
+    private function replyFailure(array $result, string $identifier, array $form): void
     {
         $this->flashLoginErrors($result);
-        $this->flashOldLoginInput($result, $email);
+        $this->flashOldLoginInput($result, $identifier, $form);
         $this->responder->redirect(self::REDIRECT);
     }
 
@@ -191,8 +195,9 @@ final class LoginPostHandler
 
     /**
      * @param array<string, mixed> $result
+     * @param array<string, mixed> $form
      */
-    private function flashOldLoginInput(array $result, string $email): void
+    private function flashOldLoginInput(array $result, string $identifier, array $form): void
     {
         $old = $result['old'] ?? null;
 
@@ -201,7 +206,41 @@ final class LoginPostHandler
             return;
         }
 
-        $this->flash->put('old', ['email' => $email]);
+        $rememberMe = $this->normalizeRememberMeValue($form);
+
+        $fallbackOld = [
+            'identifier' => $identifier,
+        ];
+
+        if ($rememberMe) {
+            $fallbackOld['remember_me'] = '1';
+        }
+
+        $this->flash->put('old', $fallbackOld);
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function handleRememberMe(array $result): void
+    {
+        $token = $result['remember_me_token'] ?? null;
+
+        if (!is_string($token) || $token === '') {
+            return;
+        }
+
+        $this->rememberMeManager->createCookie($token);
+    }
+
+    /**
+     * @param array<string, mixed> $form
+     */
+    private function normalizeRememberMeValue(array $form): bool
+    {
+        $value = $form['remember_me'] ?? null;
+
+        return $value === '1' || $value === 'on';
     }
 
     private function strOrEmpty(mixed $value): string

--- a/app/Handler/Auth/LogoutHandler.php
+++ b/app/Handler/Auth/LogoutHandler.php
@@ -8,6 +8,7 @@ use App\Core\Contract\FlashInterface;
 use App\Core\ErrorCode;
 use App\Core\MessageManager;
 use App\Http\Contract\ResponderInterface;
+use App\Security\Contract\RememberMeCookieManagerInterface;
 use App\Service\Security\Contract\SecurityServiceInterface;
 
 final class LogoutHandler
@@ -18,12 +19,15 @@ final class LogoutHandler
         private SecurityServiceInterface $securityService,
         private FlashInterface $flash,
         private ResponderInterface $responder,
+        private RememberMeCookieManagerInterface $rememberMeManager,
     ) {
     }
 
     public function handle(): void
     {
         $this->securityService->logout();
+
+        $this->rememberMeManager->expireCookie();
 
         $this->flash->add(
             'success',

--- a/app/Middleware/RememberMeMiddleware.php
+++ b/app/Middleware/RememberMeMiddleware.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use App\Http\Middleware\MiddlewareInterface;
+use App\Http\Request;
+use App\Security\Contract\AuthCheckerInterface;
+use App\Security\Contract\RememberMeCookieManagerInterface;
+use App\Service\Security\Contract\RememberMeServiceInterface;
+
+final class RememberMeMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private AuthCheckerInterface $authChecker,
+        private RememberMeCookieManagerInterface $cookieManager,
+        private RememberMeServiceInterface $rememberMeService,
+    ) {
+    }
+
+    public function handle(Request $request, string $uri, string $method): bool
+    {
+        if ($this->authChecker->isAuthenticated($request)) {
+            return true;
+        }
+
+        $token = $this->cookieManager->getCookieValue();
+        if ($token === null) {
+            return true;
+        }
+
+        $restored = $this->rememberMeService->restoreSessionFromToken($token);
+        if (!$restored) {
+            $this->cookieManager->expireCookie();
+        }
+
+        return true;
+    }
+}

--- a/app/Model/Contract/UserTokenModelInterface.php
+++ b/app/Model/Contract/UserTokenModelInterface.php
@@ -10,9 +10,13 @@ interface UserTokenModelInterface
 
     public function createPasswordResetToken(int $userId, string $tokenHash, \DateTimeImmutable $expiresAt): bool;
 
+    public function createRememberMeToken(int $userId, string $tokenHash, \DateTimeImmutable $expiresAt): bool;
+
     public function hasActiveUnusedPasswordResetToken(int $userId): bool;
 
     public function invalidatePasswordResetToken(int $userId): bool;
+
+    public function invalidateRememberMeToken(int $userId): bool;
 
     /**
      * @return array<string, mixed>|null
@@ -23,6 +27,11 @@ interface UserTokenModelInterface
      * @return array<string, mixed>|null
      */
     public function findPasswordResetContextByHash(string $hashBinary32): ?array;
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findRememberMeContextByHash(string $hashBinary32): ?array;
 
     public function activateByHash(string $hashBinary32): bool;
 

--- a/app/Model/UserTokenModel.php
+++ b/app/Model/UserTokenModel.php
@@ -23,15 +23,6 @@ class UserTokenModel implements UserTokenModelInterface
     /** @var string The database table name for user tokens */
     protected string $table = 'user_token';
 
-    /**
-     * Constructor.
-     *
-     * Initializes the model with a SqlHelper instance for performing
-     * parameterized SQL queries safely and consistently.
-     *
-     * @param SqlHelperInterface $sqlHelper
-     *     Helper utility for preparing and executing SQL queries.
-     */
     public function __construct(
         private SqlHelperInterface $sqlHelper
     ) {
@@ -43,14 +34,7 @@ class UserTokenModel implements UserTokenModelInterface
      */
 
     /**
-     * Creates or updates a token for a given user and type.
-     *
-     * @param int $userId
-     * @param string $purpose
-     * @param string $hashBinary32
-     * @param \DateTimeInterface $expiresAt
-     *
-     * @return bool
+     * Creates or updates a token for a given user and purpose.
      */
     private function createToken(
         int $userId,
@@ -76,10 +60,10 @@ class UserTokenModel implements UserTokenModelInterface
         ";
 
         $params = [
-            ':user_id'       => $userId,
-            ':purpose'       => $purpose,
-            ':token_hash'    => $hashBinary32,
-            ':expires_at'    => $expiresAt->format('Y-m-d H:i:s'),
+            ':user_id'    => $userId,
+            ':purpose'    => $purpose,
+            ':token_hash' => $hashBinary32,
+            ':expires_at' => $expiresAt->format('Y-m-d H:i:s'),
         ];
 
         $st = $this->sqlHelper->request($sql, $params);
@@ -89,9 +73,6 @@ class UserTokenModel implements UserTokenModelInterface
 
     /**
      * Finds token + user context by hash and purpose.
-     *
-     * @param string $hashBinary32
-     * @param string $purpose
      *
      * @return array<string, mixed>|null
      */
@@ -123,30 +104,6 @@ class UserTokenModel implements UserTokenModelInterface
         return $row ?: null;
     }
 
-    public function activateByHash(string $hashBinary32): bool
-    {
-        $sql = "
-            UPDATE user u
-            JOIN {$this->table} t ON t.user_id = u.id
-            SET
-                u.status = 'active',
-                t.used    = 1,
-                t.used_at = NOW()
-            WHERE
-                t.token_hash = :hash
-                AND t.purpose = 'confirmation'
-                AND t.used = 0
-                AND t.expires_at > NOW()
-                AND u.status <> 'active'
-        ";
-
-        $st = $this->sqlHelper->request($sql, [
-            ':hash' => $hashBinary32,
-        ]);
-
-        return $st->rowCount() >= 1;
-    }
-
     /**
      * Returns true if the user already has an active (unused + not expired) token
      * for the given purpose.
@@ -171,7 +128,7 @@ class UserTokenModel implements UserTokenModelInterface
         return (bool) $st->fetchColumn();
     }
 
-    public function invalidatePasswordResetToken(int $userId): bool
+    private function invalidateActiveTokenByPurpose(int $userId, string $purpose): bool
     {
         $sql = "
             UPDATE {$this->table}
@@ -180,22 +137,65 @@ class UserTokenModel implements UserTokenModelInterface
                 used_at = NOW()
             WHERE
                 user_id = :user_id
-                AND purpose = 'password_reset'
+                AND purpose = :purpose
                 AND used = 0
                 AND expires_at > NOW()
         ";
 
         $st = $this->sqlHelper->request($sql, [
             ':user_id' => $userId,
+            ':purpose' => $purpose,
         ]);
 
         return $st->rowCount() >= 1;
     }
 
+    /* ============================================================
+     * Confirmation
+     * ============================================================
+     */
+
     public function createConfirmationToken(int $userId, string $hashBinary32, \DateTimeImmutable $expiresAt): bool
     {
         return $this->createToken($userId, 'confirmation', $hashBinary32, $expiresAt);
     }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findConfirmationContextByHash(string $hashBinary32): ?array
+    {
+        return $this->findContextByHashAndPurpose($hashBinary32, 'confirmation');
+    }
+
+    public function activateByHash(string $hashBinary32): bool
+    {
+        $sql = "
+            UPDATE user u
+            JOIN {$this->table} t ON t.user_id = u.id
+            SET
+                u.status = 'active',
+                t.used   = 1,
+                t.used_at = NOW()
+            WHERE
+                t.token_hash = :hash
+                AND t.purpose = 'confirmation'
+                AND t.used = 0
+                AND t.expires_at > NOW()
+                AND u.status <> 'active'
+        ";
+
+        $st = $this->sqlHelper->request($sql, [
+            ':hash' => $hashBinary32,
+        ]);
+
+        return $st->rowCount() >= 1;
+    }
+
+    /* ============================================================
+     * Password reset
+     * ============================================================
+     */
 
     public function createPasswordResetToken(int $userId, string $hashBinary32, \DateTimeImmutable $expiresAt): bool
     {
@@ -207,11 +207,14 @@ class UserTokenModel implements UserTokenModelInterface
         return $this->hasActiveUnusedToken($userId, 'password_reset');
     }
 
-    public function findConfirmationContextByHash(string $hashBinary32): ?array
+    public function invalidatePasswordResetToken(int $userId): bool
     {
-        return $this->findContextByHashAndPurpose($hashBinary32, 'confirmation');
+        return $this->invalidateActiveTokenByPurpose($userId, 'password_reset');
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
     public function findPasswordResetContextByHash(string $hashBinary32): ?array
     {
         return $this->findContextByHashAndPurpose($hashBinary32, 'password_reset');
@@ -219,7 +222,6 @@ class UserTokenModel implements UserTokenModelInterface
 
     public function consumePasswordResetTokenAndUpdatePassword(string $hashBinary32, string $passwordHash): bool
     {
-        // Une seule requête : met à jour user + token (comme votre activateByHash)
         $sql = "
             UPDATE user u
             JOIN {$this->table} t ON t.user_id = u.id
@@ -240,5 +242,28 @@ class UserTokenModel implements UserTokenModelInterface
         ]);
 
         return $st->rowCount() >= 1;
+    }
+
+    /* ============================================================
+     * Remember me
+     * ============================================================
+     */
+
+    public function createRememberMeToken(int $userId, string $hashBinary32, \DateTimeImmutable $expiresAt): bool
+    {
+        return $this->createToken($userId, 'remember_me', $hashBinary32, $expiresAt);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findRememberMeContextByHash(string $hashBinary32): ?array
+    {
+        return $this->findContextByHashAndPurpose($hashBinary32, 'remember_me');
+    }
+
+    public function invalidateRememberMeToken(int $userId): bool
+    {
+        return $this->invalidateActiveTokenByPurpose($userId, 'remember_me');
     }
 }

--- a/app/Security/Contract/RememberMeCookieManagerInterface.php
+++ b/app/Security/Contract/RememberMeCookieManagerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security\Contract;
+
+interface RememberMeCookieManagerInterface
+{
+    /**
+     * Creates the persistent remember me cookie.
+     */
+    public function createCookie(string $rawToken): void;
+
+    /**
+     * Expires the remember me cookie immediately.
+     */
+    public function expireCookie(): void;
+
+    /**
+     * Returns the remember me cookie value if present and non-empty.
+     */
+    public function getCookieValue(): ?string;
+}

--- a/app/Security/RememberMeCookieManager.php
+++ b/app/Security/RememberMeCookieManager.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Security\Contract\RememberMeCookieManagerInterface;
+
+final class RememberMeCookieManager implements RememberMeCookieManagerInterface
+{
+    private const COOKIE_NAME = 'remember_me';
+    private const COOKIE_TTL  = 2592000; // 30 days
+    private const COOKIE_PATH = '/coding-blog';
+
+    public function createCookie(string $rawToken): void
+    {
+        $rawToken = trim($rawToken);
+
+        if ($rawToken === '') {
+            return;
+        }
+
+        setcookie(
+            self::COOKIE_NAME,
+            $rawToken,
+            [
+                'expires'  => time() + self::COOKIE_TTL,
+                'path'     => self::COOKIE_PATH,
+                'secure'   => $this->isSecureRequest(),
+                'httponly' => true,
+                'samesite' => 'Lax',
+            ]
+        );
+    }
+
+    public function expireCookie(): void
+    {
+        setcookie(
+            self::COOKIE_NAME,
+            '',
+            [
+                'expires'  => time() - 3600,
+                'path'     => self::COOKIE_PATH,
+                'secure'   => $this->isSecureRequest(),
+                'httponly' => true,
+                'samesite' => 'Lax',
+            ]
+        );
+    }
+
+    public function getCookieValue(): ?string
+    {
+        $value = $_COOKIE[self::COOKIE_NAME] ?? null;
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value !== '' ? $value : null;
+    }
+
+    private function isSecureRequest(): bool
+    {
+        return $this->isHttpsEnabled()
+            || $this->isHttpsPort()
+            || $this->isForwardedHttps();
+    }
+
+    private function isHttpsEnabled(): bool
+    {
+        $https = $_SERVER['HTTPS'] ?? null;
+
+        return is_string($https)
+            && $https             !== ''
+            && strtolower($https) !== 'off';
+    }
+
+    private function isHttpsPort(): bool
+    {
+        $serverPort = $_SERVER['SERVER_PORT'] ?? null;
+
+        return is_string($serverPort) && $serverPort === '443';
+    }
+
+    private function isForwardedHttps(): bool
+    {
+        $forwardedProto = $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? null;
+
+        return is_string($forwardedProto)
+        && strtolower($forwardedProto) === 'https';
+    }
+}

--- a/app/Security/SessionAuthChecker.php
+++ b/app/Security/SessionAuthChecker.php
@@ -23,14 +23,16 @@ final class SessionAuthChecker implements AuthCheckerInterface
     {
     }
 
-    public function isAuthenticated(Request $request): bool
+    // @SuppressWarnings(PHPMD.UnusedFormalParameter)
+    public function isAuthenticated(Request $_request): bool
     {
         $user = $this->session->get('user');
         return is_array($user) && isset($user['id']);
     }
 
     /** @return list<string> */
-    public function getRoles(Request $request): array
+    // @SuppressWarnings(PHPMD.UnusedFormalParameter)
+    public function getRoles(Request $_request): array
     {
         $user = $this->session->get('user');
         if (!is_array($user)) {
@@ -52,7 +54,8 @@ final class SessionAuthChecker implements AuthCheckerInterface
         return $out;
     }
 
-    public function getUserId(Request $request): ?int
+    // @SuppressWarnings(PHPMD.UnusedFormalParameter)
+    public function getUserId(Request $_request): ?int
     {
         $user = $this->session->get('user');
         return (is_array($user) && isset($user['id']) && is_int($user['id']))

--- a/app/Service/Security/Contract/LoginServiceInterface.php
+++ b/app/Service/Security/Contract/LoginServiceInterface.php
@@ -7,16 +7,17 @@ namespace App\Service\Security\Contract;
 interface LoginServiceInterface
 {
     /**
-     * Attempts to authenticate a user.
-     *
-     * @param array<string, mixed> $credentials
-     *
-     * @return array{
-     *   ok?: bool,
-     *   error?: string,
-     *   errors?: list<string>,
-     *   old?: array<string, mixed>
-     * }
-     */
+    * Attempts to authenticate a user.
+    *
+    * @param array<string, mixed> $credentials
+    *
+    * @return array{
+    *   ok?: true,
+    *   remember_me_token?: string,
+    *   error?: string,
+    *   errors?: list<string|int>,
+    *   old?: array{identifier:string, remember_me?: string}
+    * }
+    */
     public function login(array $credentials): array;
 }

--- a/app/Service/Security/Contract/RememberMeServiceInterface.php
+++ b/app/Service/Security/Contract/RememberMeServiceInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Security\Contract;
+
+interface RememberMeServiceInterface
+{
+    /**
+     * Generates and persists a remember me token for the given user,
+     * then returns the raw token to be stored in a secure cookie.
+     */
+    public function createRememberMeToken(int $userId): ?string;
+
+    /**
+     * Attempts to restore an authenticated session from a raw remember me token.
+     *
+     * Returns true if the session was successfully restored, false otherwise.
+     */
+    public function restoreSessionFromToken(string $rawToken): bool;
+
+    /**
+     * Invalidates the active remember me token for the given user.
+     */
+    public function invalidateRememberMeForUser(int $userId): bool;
+}

--- a/app/Service/Security/LoginService.php
+++ b/app/Service/Security/LoginService.php
@@ -10,6 +10,7 @@ use App\Core\Logger;
 use App\Model\Contract\UserModelInterface;
 use App\Model\Entity\UserEntity;
 use App\Service\Security\Contract\LoginServiceInterface;
+use App\Service\Security\Contract\RememberMeServiceInterface;
 use App\Validation\Contract\FormValidatorInterface;
 
 final class LoginService implements LoginServiceInterface
@@ -18,6 +19,7 @@ final class LoginService implements LoginServiceInterface
         private FormValidatorInterface $validator,
         private UserModelInterface $userModel,
         private SessionInterface $session,
+        private RememberMeServiceInterface $rememberMeService,
         // Extension prévue : throttle dédié login
         // private LoginThrottleServiceInterface $throttle,
     ) {
@@ -27,8 +29,9 @@ final class LoginService implements LoginServiceInterface
      * @param array<string,mixed> $form
      * @return array{
      *   ok?: true,
+     *   remember_me_token?: string,
      *   errors?: list<string|int>,
-     *   old?: array{identifier:string}
+     *   old?: array{identifier:string, remember_me?: string}
      * }
      */
     public function login(array $form): array
@@ -54,15 +57,16 @@ final class LoginService implements LoginServiceInterface
      * @param array<string,mixed> $form
      * @return array{
      *   ok?: true,
+     *   remember_me_token?: string,
      *   errors?: list<string|int>,
-     *   old?: array{identifier:string}
+     *   old?: array{identifier:string, remember_me?: string}
      * }
      */
     private function doLoginFlow(array $form): array
     {
         $channel = 'auth';
 
-        [$identifier, $password, $old] = $this->sanitizeLoginForm($form);
+        [$identifier, $password, $rememberMe, $old] = $this->sanitizeLoginForm($form);
 
         $errors = $this->validateLoginForm($identifier, $password);
         if ($errors !== []) {
@@ -96,12 +100,12 @@ final class LoginService implements LoginServiceInterface
 
         $this->openAuthenticatedSession($userId, $client['ip'], $channel);
 
-        return ['ok' => true];
+        return $this->buildSuccessResult($rememberMe, $userId, $client['ip'], $channel);
     }
 
     /**
-     * @param array{identifier:string} $old
-     * @return array{errors:list<string|int>, old:array{identifier:string}}|null
+     * @param array{identifier:string, remember_me?: string} $old
+     * @return array{errors:list<string|int>, old:array{identifier:string, remember_me?: string}}|null
      */
     private function failIfUserMissing(?UserEntity $user, string $ip, array $old, string $channel): ?array
     {
@@ -118,8 +122,8 @@ final class LoginService implements LoginServiceInterface
     }
 
     /**
-     * @param array{identifier:string} $old
-     * @return array{errors:list<string|int>, old:array{identifier:string}}|null
+     * @param array{identifier:string, remember_me?: string} $old
+     * @return array{errors:list<string|int>, old:array{identifier:string, remember_me?: string}}|null
      */
     private function failIfPasswordInvalid(UserEntity $user, string $password, string $ip, array $old, string $channel): ?array
     {
@@ -139,8 +143,8 @@ final class LoginService implements LoginServiceInterface
     }
 
     /**
-     * @param array{identifier:string} $old
-     * @return array{errors:list<string|int>, old:array{identifier:string}}|null
+     * @param array{identifier:string, remember_me?: string} $old
+     * @return array{errors:list<string|int>, old:array{identifier:string, remember_me?: string}}|null
      */
     private function failIfUserInactive(UserEntity $user, string $ip, array $old, string $channel): ?array
     {
@@ -161,8 +165,8 @@ final class LoginService implements LoginServiceInterface
     }
 
     /**
-     * @param array{identifier:string} $old
-     * @return array{errors:list<string|int>, old:array{identifier:string}}|null
+     * @param array{identifier:string, remember_me?: string} $old
+     * @return array{errors:list<string|int>, old:array{identifier:string, remember_me?: string}}|null
      */
     private function failIfUserIdInvalid(int $userId, string $ip, array $old, string $channel): ?array
     {
@@ -203,12 +207,20 @@ final class LoginService implements LoginServiceInterface
 
     /**
      * @param array<string,mixed> $form
-     * @return array{identifier:string}
+     * @return array{identifier:string, remember_me?: string}
      */
     private function safeOldFromForm(array $form): array
     {
         $identifier = is_string($form['identifier'] ?? null) ? trim($form['identifier']) : '';
-        return ['identifier' => $identifier];
+        $rememberMe = $this->normalizeRememberMeValue($form);
+
+        $old = ['identifier' => $identifier];
+
+        if ($rememberMe) {
+            $old['remember_me'] = '1';
+        }
+
+        return $old;
     }
 
     /**
@@ -241,14 +253,31 @@ final class LoginService implements LoginServiceInterface
 
     /**
      * @param array<string,mixed> $form
-     * @return array{0:string,1:string,2:array{identifier:string}}
+     */
+    private function normalizeRememberMeValue(array $form): bool
+    {
+        $value = $form['remember_me'] ?? null;
+
+        return $value === '1' || $value === 'on';
+    }
+
+    /**
+     * @param array<string,mixed> $form
+     * @return array{0:string,1:string,2:bool,3:array{identifier:string, remember_me?: string}}
      */
     private function sanitizeLoginForm(array $form): array
     {
         $identifier = $this->trimmedStringField($form, 'identifier');
         $password   = $this->rawStringField($form, 'password');
+        $rememberMe = $this->normalizeRememberMeValue($form);
 
-        return [$identifier, $password, ['identifier' => $identifier]];
+        $old = ['identifier' => $identifier];
+
+        if ($rememberMe) {
+            $old['remember_me'] = '1';
+        }
+
+        return [$identifier, $password, $rememberMe, $old];
     }
 
     /**
@@ -303,5 +332,32 @@ final class LoginService implements LoginServiceInterface
     private function extractUserStatus(UserEntity $user): ?string
     {
         return $user->getStatus();
+    }
+
+    /**
+     * @return array{ok:true, remember_me_token?: string}
+     */
+    private function buildSuccessResult(bool $rememberMe, int $userId, string $ip, string $channel): array
+    {
+        if (!$rememberMe) {
+            return ['ok' => true];
+        }
+
+        $rememberMeToken = $this->rememberMeService->createRememberMeToken($userId);
+
+        if ($rememberMeToken === null) {
+            Logger::logCodeAndGetMessage($channel, 'warning', ErrorCode::AUTH_TECHNICAL_ERROR, [
+                'reason'  => 'remember_me_token_creation_failed',
+                'user_id' => $userId,
+                'ip'      => $ip,
+            ]);
+
+            return ['ok' => true];
+        }
+
+        return [
+            'ok'                => true,
+            'remember_me_token' => $rememberMeToken,
+        ];
     }
 }

--- a/app/Service/Security/LogoutService.php
+++ b/app/Service/Security/LogoutService.php
@@ -8,23 +8,33 @@ use App\Core\Contract\SessionInterface;
 use App\Core\ErrorCode;
 use App\Core\Logger;
 use App\Service\Security\Contract\LogoutServiceInterface;
+use App\Service\Security\Contract\RememberMeServiceInterface;
 
 final class LogoutService implements LogoutServiceInterface
 {
     public function __construct(
         private SessionInterface $session,
+        private RememberMeServiceInterface $rememberMeService,
     ) {
     }
 
     public function logout(): void
     {
-        $userId = $this->session->get('user_id');
+        $user = $this->session->get('user');
+
+        $userId = (is_array($user) && isset($user['id']) && is_int($user['id']))
+            ? $user['id']
+            : null;
+
+        if ($userId !== null) {
+            $this->rememberMeService->invalidateRememberMeForUser($userId);
+        }
 
         $this->session->clear();
         $this->session->regenerateAndDeleteOld();
 
         Logger::logCodeAndGetMessage('auth', 'info', ErrorCode::AUTH_LOGOUT_SUCCESS, [
-            'user_id' => is_int($userId) || is_string($userId) ? $userId : null,
+            'user_id' => $userId,
         ]);
     }
 }

--- a/app/Service/Security/RememberMeService.php
+++ b/app/Service/Security/RememberMeService.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Security;
+
+use App\Core\Contract\SessionInterface;
+use App\Core\ErrorCode;
+use App\Core\Logger;
+use App\Model\Contract\UserTokenModelInterface;
+use App\Security\Contract\TokenGeneratorInterface;
+use App\Service\Security\Contract\RememberMeServiceInterface;
+use DateTimeImmutable;
+use Throwable;
+
+final class RememberMeService implements RememberMeServiceInterface
+{
+    private const TTL_DAYS = 30;
+
+    public function __construct(
+        private UserTokenModelInterface $userTokenModel,
+        private TokenGeneratorInterface $tokenGenerator,
+        private SessionInterface $session,
+    ) {
+    }
+
+    public function createRememberMeToken(int $userId): ?string
+    {
+        if ($userId <= 0) {
+            Logger::logCodeAndGetMessage('auth', 'warning', ErrorCode::AUTH_TECHNICAL_ERROR, [
+                'reason'  => 'remember_me_invalid_user_id',
+                'user_id' => $userId,
+            ]);
+
+            return null;
+        }
+
+        try {
+            $rawToken   = $this->tokenGenerator->generateUrlSafeToken();
+            $tokenHash  = $this->tokenGenerator->hashToken($rawToken);
+            $expiresAt  = new DateTimeImmutable('+' . self::TTL_DAYS . ' days');
+            $persisted  = $this->userTokenModel->createRememberMeToken($userId, $tokenHash, $expiresAt);
+
+            if (!$persisted) {
+                Logger::logCodeAndGetMessage('auth', 'warning', ErrorCode::AUTH_TECHNICAL_ERROR, [
+                    'reason'  => 'remember_me_token_not_persisted',
+                    'user_id' => $userId,
+                ]);
+
+                return null;
+            }
+
+            Logger::getLogger('auth')->info('remember_me_token_created', [
+                'user_id'    => $userId,
+                'expires_at' => $expiresAt->format('Y-m-d H:i:s'),
+            ]);
+
+            return $rawToken;
+        } catch (Throwable $e) {
+            Logger::logCodeAndGetMessage('auth', 'error', ErrorCode::AUTH_TECHNICAL_ERROR, [
+                'reason'    => 'remember_me_create_throwable',
+                'user_id'   => $userId,
+                'exception' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    public function restoreSessionFromToken(string $rawToken): bool
+    {
+        $rawToken = trim($rawToken);
+
+        if ($rawToken === '') {
+            return false;
+        }
+
+        try {
+            $tokenHash = $this->tokenGenerator->hashToken($rawToken);
+            $context   = $this->userTokenModel->findRememberMeContextByHash($tokenHash);
+
+            if (!is_array($context)) {
+                Logger::getLogger('auth')->info('remember_me_restore_failed', [
+                    'reason' => 'token_not_found',
+                ]);
+
+                return false;
+            }
+
+            $userId = $this->extractUserId($context);
+
+            if (!$this->isRestorableContext($context, $userId)) {
+                return false;
+            }
+
+            $this->session->regenerateAndDeleteOld();
+            $this->session->set('user', [
+                'id'    => $userId,
+                'roles' => ['USER'],
+            ]);
+
+            Logger::getLogger('auth')->info('remember_me_restore_success', [
+                'user_id' => $userId,
+            ]);
+
+            return true;
+        } catch (Throwable $e) {
+            Logger::logCodeAndGetMessage('auth', 'error', ErrorCode::AUTH_TECHNICAL_ERROR, [
+                'reason'    => 'remember_me_restore_throwable',
+                'exception' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+
+    public function invalidateRememberMeForUser(int $userId): bool
+    {
+        if ($userId <= 0) {
+            return false;
+        }
+
+        try {
+            $invalidated = $this->userTokenModel->invalidateRememberMeToken($userId);
+
+            Logger::getLogger('auth')->info('remember_me_token_invalidated', [
+                'user_id'     => $userId,
+                'invalidated' => $invalidated,
+            ]);
+
+            return $invalidated;
+        } catch (Throwable $e) {
+            Logger::logCodeAndGetMessage('auth', 'error', ErrorCode::AUTH_TECHNICAL_ERROR, [
+                'reason'    => 'remember_me_invalidate_throwable',
+                'user_id'   => $userId,
+                'exception' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function isRestorableContext(array $context, int $userId): bool
+    {
+        if ($userId <= 0) {
+            Logger::logCodeAndGetMessage('auth', 'warning', ErrorCode::AUTH_TECHNICAL_ERROR, [
+                'reason' => 'remember_me_missing_user_id',
+            ]);
+
+            return false;
+        }
+
+        if ($this->isTokenUsed($context)) {
+            Logger::getLogger('auth')->info('remember_me_restore_failed', [
+                'reason'  => 'token_used',
+                'user_id' => $userId,
+            ]);
+
+            return false;
+        }
+
+        if ($this->isTokenExpired($context)) {
+            $this->invalidateRememberMeForUser($userId);
+
+            Logger::getLogger('auth')->info('remember_me_restore_failed', [
+                'reason'  => 'token_expired',
+                'user_id' => $userId,
+            ]);
+
+            return false;
+        }
+
+        if (!$this->isUserActive($context)) {
+            $this->invalidateRememberMeForUser($userId);
+
+            Logger::getLogger('auth')->info('remember_me_restore_failed', [
+                'reason'      => 'user_not_active',
+                'user_id'     => $userId,
+                'user_status' => $context['user_status'] ?? null,
+            ]);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function extractUserId(array $context): int
+    {
+        $userId = $context['user_id'] ?? null;
+
+        return is_numeric($userId) ? (int) $userId : 0;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function isTokenUsed(array $context): bool
+    {
+        $used = $context['used'] ?? null;
+
+        if (is_int($used)) {
+            return $used === 1;
+        }
+
+        if (is_string($used)) {
+            return $used === '1';
+        }
+
+        if (is_bool($used)) {
+            return $used;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function isTokenExpired(array $context): bool
+    {
+        $expired = $context['is_expired'] ?? null;
+
+        if (is_int($expired)) {
+            return $expired === 1;
+        }
+
+        if (is_string($expired)) {
+            return $expired === '1';
+        }
+
+        if (is_bool($expired)) {
+            return $expired;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function isUserActive(array $context): bool
+    {
+        $status = $context['user_status'] ?? null;
+
+        return $status === null || $status === 'active';
+    }
+}

--- a/app/Views/security/login.html.twig
+++ b/app/Views/security/login.html.twig
@@ -34,6 +34,20 @@
       { autocomplete: 'current-password' }
     ) }}
 
+    <div class="form-check mb-3">
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="remember_me"
+        name="remember_me"
+        value="1"
+        {% if old.remember_me|default('') == '1' %}checked{% endif %}
+      >
+      <label class="form-check-label" for="remember_me">
+        Remember Me
+      </label>
+    </div>
+
     {{ fields.honeypot(honeypot_name) }}
 
     {% include 'templates/components/turnstile_widget.html.twig' with {

--- a/public/index.php
+++ b/public/index.php
@@ -69,6 +69,7 @@ $router = new Router(
 
 // 7.1) Middlewares applicatifs
 $router->addMiddleware($psr->get(\App\Middleware\SecurityHeadersMiddleware::class));
+$router->addMiddleware($psr->get(\App\Middleware\RememberMeMiddleware::class));
 $router->addMiddleware($psr->get(\App\Middleware\CsrfMiddleware::class));
 $router->addMiddleware($psr->get(\App\Middleware\AuthenticationMiddleware::class));
 

--- a/tests/Unit/Controller/LoginControllerTest.php
+++ b/tests/Unit/Controller/LoginControllerTest.php
@@ -13,6 +13,7 @@ use App\Http\Contract\ResponderInterface;
 use App\Http\Request;
 use App\Security\Contract\CsrfTokenInterface;
 use App\Security\Contract\HoneypotValidatorInterface;
+use App\Security\Contract\RememberMeCookieManagerInterface;
 use App\Security\Contract\SubmissionDelayValidatorInterface;
 use App\Security\Guard\Contract\HoneypotGuardInterface;
 use App\Security\Guard\Contract\RateLimitGuardInterface;
@@ -34,6 +35,7 @@ final class LoginControllerTest extends TestCase
     private HoneypotGuardInterface&MockObject $honeypotGuard;
     private SubmissionDelayGuardInterface&MockObject $submissionDelayGuard;
     private RateLimitGuardInterface&MockObject $rateLimitGuard;
+    private RememberMeCookieManagerInterface&MockObject $rememberMeCookieManager;
 
     private LoginController $controller;
 
@@ -53,6 +55,7 @@ final class LoginControllerTest extends TestCase
         $this->honeypotGuard            = $this->createMock(HoneypotGuardInterface::class);
         $this->submissionDelayGuard     = $this->createMock(SubmissionDelayGuardInterface::class);
         $this->rateLimitGuard           = $this->createMock(RateLimitGuardInterface::class);
+        $this->rememberMeCookieManager  = $this->createMock(RememberMeCookieManagerInterface::class);
 
         $getHandler = new LoginGetHandler(
             $this->view,
@@ -70,6 +73,7 @@ final class LoginControllerTest extends TestCase
             $this->honeypotGuard,
             $this->submissionDelayGuard,
             $this->rateLimitGuard,
+            $this->rememberMeCookieManager,
         );
 
         $this->controller = new LoginController(
@@ -161,5 +165,9 @@ final class LoginControllerTest extends TestCase
             ->method('redirect');
 
         $this->controller->login();
+
+        $this->rememberMeCookieManager
+            ->expects($this->never())
+            ->method('createCookie');
     }
 }

--- a/tests/Unit/Controller/LogoutControllerTest.php
+++ b/tests/Unit/Controller/LogoutControllerTest.php
@@ -10,6 +10,7 @@ use App\Core\ErrorCode;
 use App\Core\MessageManager;
 use App\Handler\Auth\LogoutHandler;
 use App\Http\Contract\ResponderInterface;
+use App\Security\Contract\RememberMeCookieManagerInterface;
 use App\Service\Security\Contract\SecurityServiceInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -19,6 +20,8 @@ final class LogoutControllerTest extends TestCase
     private SecurityServiceInterface&MockObject $securityService;
     private FlashInterface&MockObject $flash;
     private ResponderInterface&MockObject $responder;
+    private RememberMeCookieManagerInterface&MockObject $rememberMeCookieManager;
+
 
     private LogoutController $controller;
 
@@ -26,14 +29,16 @@ final class LogoutControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->securityService = $this->createMock(SecurityServiceInterface::class);
-        $this->flash           = $this->createMock(FlashInterface::class);
-        $this->responder       = $this->createMock(ResponderInterface::class);
+        $this->securityService          = $this->createMock(SecurityServiceInterface::class);
+        $this->flash                    = $this->createMock(FlashInterface::class);
+        $this->responder                = $this->createMock(ResponderInterface::class);
+        $this->rememberMeCookieManager  = $this->createMock(RememberMeCookieManagerInterface::class);
 
         $handler = new LogoutHandler(
             $this->securityService,
             $this->flash,
             $this->responder,
+            $this->rememberMeCookieManager,
         );
 
         $this->controller = new LogoutController($handler);

--- a/tests/Unit/Core/Container/AuthServiceProviderTest.php
+++ b/tests/Unit/Core/Container/AuthServiceProviderTest.php
@@ -23,6 +23,7 @@ use App\Http\Contract\ResponderInterface;
 use App\Log\LogContextNormalizer;
 use App\Security\Contract\CsrfTokenInterface;
 use App\Security\Contract\HoneypotValidatorInterface;
+use App\Security\Contract\RememberMeCookieManagerInterface;
 use App\Security\Contract\SubmissionDelayValidatorInterface;
 use App\Security\Contract\TurnstileValidatorInterface;
 use App\Security\Guard\Contract\HoneypotGuardInterface;
@@ -80,6 +81,7 @@ final class AuthServiceProviderTest extends TestCase
             FlashInterface::class                    => $this->createMock(FlashInterface::class),
             ResponderInterface::class                => $this->createMock(ResponderInterface::class),
             CsrfTokenInterface::class                => $this->createMock(CsrfTokenInterface::class),
+            RememberMeCookieManagerInterface::class  => $this->createMock(RememberMeCookieManagerInterface::class),
             HoneypotValidatorInterface::class        => $this->createMock(HoneypotValidatorInterface::class),
             SubmissionDelayValidatorInterface::class => $this->createMock(SubmissionDelayValidatorInterface::class),
             TurnstileValidatorInterface::class       => $this->createMock(TurnstileValidatorInterface::class),

--- a/tests/Unit/Core/Container/UserServiceProviderTest.php
+++ b/tests/Unit/Core/Container/UserServiceProviderTest.php
@@ -24,6 +24,7 @@ use App\Service\Security\ConfirmationResendService;
 use App\Service\Security\Contract\ForgotPasswordServiceInterface;
 use App\Service\Security\Contract\LoginServiceInterface;
 use App\Service\Security\Contract\LogoutServiceInterface;
+use App\Service\Security\Contract\RememberMeServiceInterface;
 use App\Service\Security\Contract\ResetPasswordServiceInterface;
 use App\Service\Security\Contract\SecurityServiceInterface;
 use App\Service\Security\ForgotPasswordService;
@@ -76,12 +77,13 @@ final class UserServiceProviderTest extends TestCase
         $sqlHelper = $this->createMock(SqlHelperInterface::class);
 
         return [
-            SqlHelperInterface::class      => $sqlHelper,
-            FormValidatorInterface::class  => $this->createMock(FormValidatorInterface::class),
-            MailerInterface::class         => $this->createMock(MailerInterface::class),
-            TokenGeneratorInterface::class => $this->createMock(TokenGeneratorInterface::class),
-            SessionInterface::class        => $this->createMock(SessionInterface::class),
-            Slugify::class                 => new Slugify(),
+            SqlHelperInterface::class          => $sqlHelper,
+            FormValidatorInterface::class      => $this->createMock(FormValidatorInterface::class),
+            MailerInterface::class             => $this->createMock(MailerInterface::class),
+            TokenGeneratorInterface::class     => $this->createMock(TokenGeneratorInterface::class),
+            SessionInterface::class            => $this->createMock(SessionInterface::class),
+            RememberMeServiceInterface::class  => $this->createMock(RememberMeServiceInterface::class),
+            Slugify::class                     => new Slugify(),
         ];
     }
 
@@ -146,9 +148,10 @@ final class UserServiceProviderTest extends TestCase
         $emailEventModel        = new EmailEventModel($sql);
 
         $container = $this->makeContainer([
-            RegistrationEventModel::class => $registrationEventModel,
-            EmailEventModel::class        => $emailEventModel,
-            SessionInterface::class       => $session,
+            RegistrationEventModel::class     => $registrationEventModel,
+            EmailEventModel::class            => $emailEventModel,
+            SessionInterface::class           => $session,
+            RememberMeServiceInterface::class => $this->createMock(RememberMeServiceInterface::class),
         ]);
 
         $registrationThrottle = $definitions[RegistrationThrottleService::class]($container);

--- a/tests/Unit/Handler/Auth/LoginPostHandlerTest.php
+++ b/tests/Unit/Handler/Auth/LoginPostHandlerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Handler\Auth;
 use App\Core\Contract\FlashInterface;
 use App\Handler\Auth\LoginPostHandler;
 use App\Http\Contract\ResponderInterface;
+use App\Security\Contract\RememberMeCookieManagerInterface;
 use App\Security\Guard\Contract\HoneypotGuardInterface;
 use App\Security\Guard\Contract\RateLimitGuardInterface;
 use App\Security\Guard\Contract\SubmissionDelayGuardInterface;
@@ -22,6 +23,7 @@ final class LoginPostHandlerTest extends TestCase
     private HoneypotGuardInterface&MockObject $honeypotGuard;
     private SubmissionDelayGuardInterface&MockObject $submissionDelayGuard;
     private RateLimitGuardInterface&MockObject $rateLimitGuard;
+    private RememberMeCookieManagerInterface&MockObject $rememberMeCookieManager;
 
     private LoginPostHandler $handler;
 
@@ -29,12 +31,13 @@ final class LoginPostHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->securityService      = $this->createMock(SecurityServiceInterface::class);
-        $this->flash                = $this->createMock(FlashInterface::class);
-        $this->responder            = $this->createMock(ResponderInterface::class);
-        $this->honeypotGuard        = $this->createMock(HoneypotGuardInterface::class);
-        $this->submissionDelayGuard = $this->createMock(SubmissionDelayGuardInterface::class);
-        $this->rateLimitGuard       = $this->createMock(RateLimitGuardInterface::class);
+        $this->securityService         = $this->createMock(SecurityServiceInterface::class);
+        $this->flash                   = $this->createMock(FlashInterface::class);
+        $this->responder               = $this->createMock(ResponderInterface::class);
+        $this->honeypotGuard           = $this->createMock(HoneypotGuardInterface::class);
+        $this->submissionDelayGuard    = $this->createMock(SubmissionDelayGuardInterface::class);
+        $this->rateLimitGuard          = $this->createMock(RateLimitGuardInterface::class);
+        $this->rememberMeCookieManager = $this->createMock(RememberMeCookieManagerInterface::class);
 
         $this->handler = new LoginPostHandler(
             $this->securityService,
@@ -43,6 +46,7 @@ final class LoginPostHandlerTest extends TestCase
             $this->honeypotGuard,
             $this->submissionDelayGuard,
             $this->rateLimitGuard,
+            $this->rememberMeCookieManager,
         );
     }
 
@@ -52,8 +56,8 @@ final class LoginPostHandlerTest extends TestCase
     private function validForm(): array
     {
         return [
-            'email'    => 'john@example.com',
-            'password' => 'StrongPassword123!',
+            'identifier'    => 'john@example.com',
+            'password'      => 'StrongPassword123!',
         ];
     }
 
@@ -177,6 +181,10 @@ final class LoginPostHandlerTest extends TestCase
             ->method('redirect')
             ->with('/coding-blog');
 
+        $this->rememberMeCookieManager
+            ->expects($this->never())
+            ->method('createCookie');
+
         $this->handler->handle($form);
     }
 
@@ -207,7 +215,7 @@ final class LoginPostHandlerTest extends TestCase
             ->expects($this->once())
             ->method('put')
             ->with('old', [
-                'email' => 'john@example.com',
+                'identifier' => 'john@example.com',
             ]);
 
         $this->responder
@@ -242,7 +250,7 @@ final class LoginPostHandlerTest extends TestCase
             ->expects($this->once())
             ->method('put')
             ->with('old', [
-                'email' => 'john@example.com',
+                'identifier' => 'john@example.com',
             ]);
 
         $this->responder
@@ -261,7 +269,7 @@ final class LoginPostHandlerTest extends TestCase
         $result = [
             'errors' => ['ERR_1'],
             'old'    => [
-                'email' => 'custom@example.com',
+                'identifier' => 'custom@example.com',
             ],
         ];
 
@@ -283,13 +291,131 @@ final class LoginPostHandlerTest extends TestCase
             ->expects($this->once())
             ->method('put')
             ->with('old', [
-                'email' => 'custom@example.com',
+                'identifier' => 'custom@example.com',
             ]);
 
         $this->responder
             ->expects($this->once())
             ->method('redirect')
             ->with('/coding-blog/login');
+
+        $this->handler->handle($form);
+    }
+
+    public function testHandleCreatesRememberMeCookieWhenLoginReturnsRememberMeToken(): void
+    {
+        $form = [
+            'identifier'  => 'john@example.com',
+            'password'    => 'StrongPassword123!',
+            'remember_me' => '1',
+        ];
+
+        $this->allowAllGuards();
+
+        $this->securityService
+            ->expects($this->once())
+            ->method('login')
+            ->with($form)
+            ->willReturn([
+                'ok'                => true,
+                'remember_me_token' => 'raw-token',
+            ]);
+
+        $this->rememberMeCookieManager
+            ->expects($this->once())
+            ->method('createCookie')
+            ->with('raw-token');
+
+        $this->flash
+            ->expects($this->once())
+            ->method('put')
+            ->with('old', []);
+
+        $this->flash
+            ->expects($this->once())
+            ->method('add')
+            ->with('success', 'Connexion réussie.');
+
+        $this->responder
+            ->expects($this->once())
+            ->method('redirect')
+            ->with('/coding-blog');
+
+        $this->handler->handle($form);
+    }
+
+    public function testHandleKeepsRememberMeOldValueWhenLoginFailsWithoutResultOld(): void
+    {
+        $form = [
+        'identifier'  => 'john@example.com',
+        'password'    => 'StrongPassword123!',
+        'remember_me' => '1',
+        ];
+
+        $this->allowAllGuards();
+
+        $this->securityService
+        ->expects($this->once())
+        ->method('login')
+        ->with($form)
+        ->willReturn([
+            'ok' => false,
+        ]);
+
+        $this->flash
+        ->expects($this->once())
+        ->method('add')
+        ->with('error', 'Échec de connexion.');
+
+        $this->flash
+        ->expects($this->once())
+        ->method('put')
+        ->with('old', [
+            'identifier'  => 'john@example.com',
+            'remember_me' => '1',
+        ]);
+
+        $this->responder
+        ->expects($this->once())
+        ->method('redirect')
+        ->with('/coding-blog/login');
+
+        $this->handler->handle($form);
+    }
+
+    public function testHandleDoesNotCreateRememberMeCookieWhenTokenIsEmpty(): void
+    {
+        $form = $this->validForm();
+
+        $this->allowAllGuards();
+
+        $this->securityService
+        ->expects($this->once())
+        ->method('login')
+        ->with($form)
+        ->willReturn([
+            'ok'                => true,
+            'remember_me_token' => '',
+        ]);
+
+        $this->rememberMeCookieManager
+        ->expects($this->never())
+        ->method('createCookie');
+
+        $this->flash
+        ->expects($this->once())
+        ->method('put')
+        ->with('old', []);
+
+        $this->flash
+        ->expects($this->once())
+        ->method('add')
+        ->with('success', 'Connexion réussie.');
+
+        $this->responder
+        ->expects($this->once())
+        ->method('redirect')
+        ->with('/coding-blog');
 
         $this->handler->handle($form);
     }

--- a/tests/Unit/Handler/Auth/LogoutHandlerTest.php
+++ b/tests/Unit/Handler/Auth/LogoutHandlerTest.php
@@ -9,6 +9,7 @@ use App\Core\ErrorCode;
 use App\Core\MessageManager;
 use App\Handler\Auth\LogoutHandler;
 use App\Http\Contract\ResponderInterface;
+use App\Security\Contract\RememberMeCookieManagerInterface;
 use App\Service\Security\Contract\SecurityServiceInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -18,6 +19,7 @@ final class LogoutHandlerTest extends TestCase
     private SecurityServiceInterface&MockObject $securityService;
     private FlashInterface&MockObject $flash;
     private ResponderInterface&MockObject $responder;
+    private RememberMeCookieManagerInterface&MockObject $rememberMeCookieManager;
 
     private LogoutHandler $handler;
 
@@ -25,14 +27,18 @@ final class LogoutHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->securityService = $this->createMock(SecurityServiceInterface::class);
-        $this->flash           = $this->createMock(FlashInterface::class);
-        $this->responder       = $this->createMock(ResponderInterface::class);
+        $this->securityService         = $this->createMock(SecurityServiceInterface::class);
+        $this->flash                   = $this->createMock(FlashInterface::class);
+        $this->responder               = $this->createMock(ResponderInterface::class);
+        $this->rememberMeCookieManager = $this->createMock(RememberMeCookieManagerInterface::class);
+
+
 
         $this->handler = new LogoutHandler(
             $this->securityService,
             $this->flash,
             $this->responder,
+            $this->rememberMeCookieManager,
         );
     }
 
@@ -41,6 +47,10 @@ final class LogoutHandlerTest extends TestCase
         $this->securityService
             ->expects($this->once())
             ->method('logout');
+
+        $this->rememberMeCookieManager
+            ->expects($this->once())
+            ->method('expireCookie');
 
         $this->flash
             ->expects($this->once())

--- a/tests/Unit/Middleware/RememberMeMiddlewareTest.php
+++ b/tests/Unit/Middleware/RememberMeMiddlewareTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+declare(strict_types=1);
+
+namespace Tests\Unit\Middleware;
+
+use App\Http\Request;
+use App\Middleware\RememberMeMiddleware;
+use App\Security\Contract\AuthCheckerInterface;
+use App\Security\Contract\RememberMeCookieManagerInterface;
+use App\Service\Security\Contract\RememberMeServiceInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class RememberMeMiddlewareTest extends TestCase
+{
+    private AuthCheckerInterface&MockObject $authChecker;
+    private RememberMeCookieManagerInterface&MockObject $cookieManager;
+    private RememberMeServiceInterface&MockObject $rememberMeService;
+
+    private RememberMeMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->authChecker       = $this->createMock(AuthCheckerInterface::class);
+        $this->cookieManager     = $this->createMock(RememberMeCookieManagerInterface::class);
+        $this->rememberMeService = $this->createMock(RememberMeServiceInterface::class);
+
+        $this->middleware = new RememberMeMiddleware(
+            $this->authChecker,
+            $this->cookieManager,
+            $this->rememberMeService
+        );
+    }
+
+    private function makeRequest(): Request
+    {
+        return new Request();
+    }
+
+    public function testHandleReturnsTrueWhenUserAlreadyAuthenticated(): void
+    {
+        $request = $this->makeRequest();
+
+        $this->authChecker
+            ->expects($this->once())
+            ->method('isAuthenticated')
+            ->with($request)
+            ->willReturn(true);
+
+        $this->cookieManager
+            ->expects($this->never())
+            ->method('getCookieValue');
+
+        $this->rememberMeService
+            ->expects($this->never())
+            ->method('restoreSessionFromToken');
+
+        $result = $this->middleware->handle(
+            $request,
+            '/coding-blog',
+            'GET'
+        );
+
+        $this->assertTrue($result);
+    }
+
+    public function testHandleReturnsTrueWhenNoRememberMeCookieExists(): void
+    {
+        $request = $this->makeRequest();
+
+        $this->authChecker
+            ->expects($this->once())
+            ->method('isAuthenticated')
+            ->with($request)
+            ->willReturn(false);
+
+        $this->cookieManager
+            ->expects($this->once())
+            ->method('getCookieValue')
+            ->willReturn(null);
+
+        $this->rememberMeService
+            ->expects($this->never())
+            ->method('restoreSessionFromToken');
+
+        $result = $this->middleware->handle(
+            $request,
+            '/coding-blog/login',
+            'GET'
+        );
+
+        $this->assertTrue($result);
+    }
+
+    public function testHandleRestoresSessionWhenRememberMeCookieIsValid(): void
+    {
+        $request = $this->makeRequest();
+
+        $this->authChecker
+            ->expects($this->once())
+            ->method('isAuthenticated')
+            ->with($request)
+            ->willReturn(false);
+
+        $this->cookieManager
+            ->expects($this->once())
+            ->method('getCookieValue')
+            ->willReturn('raw-token');
+
+        $this->rememberMeService
+            ->expects($this->once())
+            ->method('restoreSessionFromToken')
+            ->with('raw-token')
+            ->willReturn(true);
+
+        $this->cookieManager
+            ->expects($this->never())
+            ->method('expireCookie');
+
+        $result = $this->middleware->handle(
+            $request,
+            '/coding-blog/account',
+            'GET'
+        );
+
+        $this->assertTrue($result);
+    }
+
+    public function testHandleExpiresCookieWhenRememberMeRestoreFails(): void
+    {
+        $request = $this->makeRequest();
+
+        $this->authChecker
+            ->expects($this->once())
+            ->method('isAuthenticated')
+            ->with($request)
+            ->willReturn(false);
+
+        $this->cookieManager
+            ->expects($this->once())
+            ->method('getCookieValue')
+            ->willReturn('invalid-token');
+
+        $this->rememberMeService
+            ->expects($this->once())
+            ->method('restoreSessionFromToken')
+            ->with('invalid-token')
+            ->willReturn(false);
+
+        $this->cookieManager
+            ->expects($this->once())
+            ->method('expireCookie');
+
+        $result = $this->middleware->handle(
+            $request,
+            '/coding-blog/account',
+            'GET'
+        );
+
+        $this->assertTrue($result);
+    }
+}

--- a/tests/Unit/Model/UserTokenModelTest.php
+++ b/tests/Unit/Model/UserTokenModelTest.php
@@ -113,7 +113,10 @@ final class UserTokenModelTest extends TestCase
             ->method('request')
             ->with(
                 $this->stringContains('UPDATE user_token'),
-                [':user_id' => 42]
+                [
+                    ':user_id' => 42,
+                    ':purpose' => 'password_reset',
+                ]
             )
             ->willReturn($this->statement);
 
@@ -132,7 +135,10 @@ final class UserTokenModelTest extends TestCase
             ->method('request')
             ->with(
                 $this->stringContains('UPDATE user_token'),
-                [':user_id' => 42]
+                [
+                    ':user_id' => 42,
+                    ':purpose' => 'password_reset',
+                ]
             )
             ->willReturn($this->statement);
 
@@ -406,5 +412,135 @@ final class UserTokenModelTest extends TestCase
         $this->assertFalse(
             $this->model->consumePasswordResetTokenAndUpdatePassword($hash, $passwordHash)
         );
+    }
+
+    public function testCreateRememberMeTokenReturnsTrueWhenInsertAffectsAtLeastOneRow(): void
+    {
+        $userId    = 42;
+        $hash      = str_repeat('k', 32);
+        $expiresAt = new \DateTimeImmutable('2026-03-28 16:00:00');
+
+        $this->sqlHelper
+        ->expects($this->once())
+        ->method('request')
+        ->with(
+            $this->stringContains('INSERT INTO user_token'),
+            [
+                ':user_id'    => $userId,
+                ':purpose'    => 'remember_me',
+                ':token_hash' => $hash,
+                ':expires_at' => '2026-03-28 16:00:00',
+            ]
+        )
+        ->willReturn($this->statement);
+
+        $this->statement
+        ->expects($this->once())
+        ->method('rowCount')
+        ->willReturn(1);
+
+        $this->assertTrue($this->model->createRememberMeToken($userId, $hash, $expiresAt));
+    }
+
+    public function testFindRememberMeContextByHashReturnsRowWhenFound(): void
+    {
+        $hash = str_repeat('l', 32);
+        $row  = [
+        'user_id'     => 42,
+        'user_status' => 'active',
+        'used'        => 0,
+        'used_at'     => null,
+        'expires_at'  => '2026-03-28 17:00:00',
+        'is_expired'  => 0,
+        ];
+
+        $this->sqlHelper
+        ->expects($this->once())
+        ->method('request')
+        ->with(
+            $this->stringContains('WHERE t.token_hash = :hash'),
+            [
+                ':hash'    => $hash,
+                ':purpose' => 'remember_me',
+            ]
+        )
+        ->willReturn($this->statement);
+
+        $this->statement
+        ->expects($this->once())
+        ->method('fetch')
+        ->with(\PDO::FETCH_ASSOC)
+        ->willReturn($row);
+
+        $this->assertSame($row, $this->model->findRememberMeContextByHash($hash));
+    }
+
+    public function testFindRememberMeContextByHashReturnsNullWhenNotFound(): void
+    {
+        $hash = str_repeat('m', 32);
+
+        $this->sqlHelper
+        ->expects($this->once())
+        ->method('request')
+        ->with(
+            $this->stringContains('WHERE t.token_hash = :hash'),
+            [
+                ':hash'    => $hash,
+                ':purpose' => 'remember_me',
+            ]
+        )
+        ->willReturn($this->statement);
+
+        $this->statement
+        ->expects($this->once())
+        ->method('fetch')
+        ->with(\PDO::FETCH_ASSOC)
+        ->willReturn(false);
+
+        $this->assertNull($this->model->findRememberMeContextByHash($hash));
+    }
+
+    public function testInvalidateRememberMeTokenReturnsTrueWhenAtLeastOneRowIsUpdated(): void
+    {
+        $this->sqlHelper
+        ->expects($this->once())
+        ->method('request')
+        ->with(
+            $this->stringContains('UPDATE user_token'),
+            [
+                ':user_id' => 42,
+                ':purpose' => 'remember_me',
+            ]
+        )
+        ->willReturn($this->statement);
+
+        $this->statement
+        ->expects($this->once())
+        ->method('rowCount')
+        ->willReturn(1);
+
+        $this->assertTrue($this->model->invalidateRememberMeToken(42));
+    }
+
+    public function testInvalidateRememberMeTokenReturnsFalseWhenNoRowIsUpdated(): void
+    {
+        $this->sqlHelper
+        ->expects($this->once())
+        ->method('request')
+        ->with(
+            $this->stringContains('UPDATE user_token'),
+            [
+                ':user_id' => 42,
+                ':purpose' => 'remember_me',
+            ]
+        )
+        ->willReturn($this->statement);
+
+        $this->statement
+        ->expects($this->once())
+        ->method('rowCount')
+        ->willReturn(0);
+
+        $this->assertFalse($this->model->invalidateRememberMeToken(42));
     }
 }

--- a/tests/Unit/Security/RememberMeCookieManagerTest.php
+++ b/tests/Unit/Security/RememberMeCookieManagerTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+final class RememberMeCookieSpy
+{
+    /** @var list<array{name:string,value:string,options:array<string,mixed>}> */
+    public static array $calls = [];
+
+    public static function reset(): void
+    {
+        self::$calls = [];
+    }
+}
+
+function setcookie(string $name, string $value = '', array|int $expires_or_options = 0): bool
+{
+    RememberMeCookieSpy::$calls[] = [
+        'name'    => $name,
+        'value'   => $value,
+        'options' => is_array($expires_or_options) ? $expires_or_options : [],
+    ];
+
+    return true;
+}
+
+namespace Tests\Unit\Security;
+
+use App\Security\RememberMeCookieManager;
+use App\Security\RememberMeCookieSpy;
+use PHPUnit\Framework\TestCase;
+
+final class RememberMeCookieManagerTest extends TestCase
+{
+    private RememberMeCookieManager $manager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        RememberMeCookieSpy::reset();
+
+        $_COOKIE = [];
+
+        unset(
+            $_SERVER['HTTPS'],
+            $_SERVER['SERVER_PORT'],
+            $_SERVER['HTTP_X_FORWARDED_PROTO']
+        );
+
+        $this->manager = new RememberMeCookieManager();
+    }
+
+    public function testCreateCookieSendsRememberMeCookie(): void
+    {
+        $before = time();
+
+        $this->manager->createCookie(' raw-token ');
+
+        $after = time();
+
+        self::assertCount(1, RememberMeCookieSpy::$calls);
+
+        $call = RememberMeCookieSpy::$calls[0];
+
+        self::assertSame('remember_me', $call['name']);
+        self::assertSame('raw-token', $call['value']);
+
+        self::assertGreaterThanOrEqual(
+            $before + 2_592_000,
+            $call['options']['expires']
+        );
+
+        self::assertLessThanOrEqual(
+            $after + 2_592_000,
+            $call['options']['expires']
+        );
+
+        self::assertSame('/coding-blog', $call['options']['path']);
+        self::assertFalse($call['options']['secure']);
+        self::assertTrue($call['options']['httponly']);
+        self::assertSame('Lax', $call['options']['samesite']);
+    }
+
+    public function testCreateCookieDoesNothingWhenTokenIsEmpty(): void
+    {
+        $this->manager->createCookie('   ');
+
+        self::assertSame([], RememberMeCookieSpy::$calls);
+    }
+
+    public function testExpireCookieSendsExpiredCookie(): void
+    {
+        $before = time();
+
+        $this->manager->expireCookie();
+
+        $after = time();
+
+        self::assertCount(1, RememberMeCookieSpy::$calls);
+
+        $call = RememberMeCookieSpy::$calls[0];
+
+        self::assertSame('remember_me', $call['name']);
+        self::assertSame('', $call['value']);
+
+        self::assertGreaterThanOrEqual(
+            $before - 3600,
+            $call['options']['expires']
+        );
+
+        self::assertLessThanOrEqual(
+            $after - 3600,
+            $call['options']['expires']
+        );
+
+        self::assertSame('/coding-blog', $call['options']['path']);
+        self::assertFalse($call['options']['secure']);
+        self::assertTrue($call['options']['httponly']);
+        self::assertSame('Lax', $call['options']['samesite']);
+    }
+
+    public function testGetCookieValueReturnsNullWhenCookieIsMissing(): void
+    {
+        self::assertNull($this->manager->getCookieValue());
+    }
+
+    public function testGetCookieValueReturnsNullWhenCookieIsNotString(): void
+    {
+        $_COOKIE['remember_me'] = ['invalid'];
+
+        self::assertNull($this->manager->getCookieValue());
+    }
+
+    public function testGetCookieValueReturnsNullWhenCookieIsEmpty(): void
+    {
+        $_COOKIE['remember_me'] = '   ';
+
+        self::assertNull($this->manager->getCookieValue());
+    }
+
+    public function testGetCookieValueReturnsTrimmedCookieValue(): void
+    {
+        $_COOKIE['remember_me'] = ' raw-token ';
+
+        self::assertSame('raw-token', $this->manager->getCookieValue());
+    }
+
+    public function testCreateCookieUsesSecureFlagWhenHttpsIsOn(): void
+    {
+        $_SERVER['HTTPS'] = 'on';
+
+        $this->manager->createCookie('raw-token');
+
+        self::assertTrue(
+            RememberMeCookieSpy::$calls[0]['options']['secure']
+        );
+    }
+
+    public function testCreateCookieUsesSecureFlagWhenServerPortIs443(): void
+    {
+        $_SERVER['SERVER_PORT'] = '443';
+
+        $this->manager->createCookie('raw-token');
+
+        self::assertTrue(
+            RememberMeCookieSpy::$calls[0]['options']['secure']
+        );
+    }
+
+    public function testCreateCookieUsesSecureFlagWhenForwardedProtoIsHttps(): void
+    {
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+
+        $this->manager->createCookie('raw-token');
+
+        self::assertTrue(
+            RememberMeCookieSpy::$calls[0]['options']['secure']
+        );
+    }
+}

--- a/tests/Unit/Service/Security/LoginServiceTest.php
+++ b/tests/Unit/Service/Security/LoginServiceTest.php
@@ -8,6 +8,7 @@ use App\Core\Contract\SessionInterface;
 use App\Core\ErrorCode;
 use App\Model\Contract\UserModelInterface;
 use App\Model\Entity\UserEntity;
+use App\Service\Security\Contract\RememberMeServiceInterface;
 use App\Service\Security\LoginService;
 use App\Validation\Contract\FormValidatorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -18,6 +19,7 @@ final class LoginServiceTest extends TestCase
     private FormValidatorInterface&MockObject $validator;
     private UserModelInterface&MockObject $userModel;
     private SessionInterface&MockObject $session;
+    private RememberMeServiceInterface&MockObject $rememberMeService;
 
     private LoginService $service;
 
@@ -28,14 +30,16 @@ final class LoginServiceTest extends TestCase
         $_SERVER['REMOTE_ADDR']     = '127.0.0.1';
         $_SERVER['HTTP_USER_AGENT'] = 'PHPUnit';
 
-        $this->validator = $this->createMock(FormValidatorInterface::class);
-        $this->userModel = $this->createMock(UserModelInterface::class);
-        $this->session   = $this->createMock(SessionInterface::class);
+        $this->validator         = $this->createMock(FormValidatorInterface::class);
+        $this->userModel         = $this->createMock(UserModelInterface::class);
+        $this->session           = $this->createMock(SessionInterface::class);
+        $this->rememberMeService = $this->createMock(RememberMeServiceInterface::class);
 
         $this->service = new LoginService(
             $this->validator,
             $this->userModel,
             $this->session,
+            $this->rememberMeService,
         );
     }
 
@@ -175,6 +179,10 @@ final class LoginServiceTest extends TestCase
                 'roles' => ['USER'],
             ]);
 
+        $this->rememberMeService
+            ->expects($this->never())
+            ->method('createRememberMeToken');
+
         $result = $this->service->login($form);
 
         $this->assertSame(['ok' => true], $result);
@@ -203,6 +211,10 @@ final class LoginServiceTest extends TestCase
         $this->session->method('regenerateAndDeleteOld');
         $this->session->method('set');
 
+        $this->rememberMeService
+            ->expects($this->never())
+            ->method('createRememberMeToken');
+
         $result = $this->service->login($form);
 
         $this->assertSame(['ok' => true], $result);
@@ -221,5 +233,143 @@ final class LoginServiceTest extends TestCase
 
         $this->assertSame([ErrorCode::AUTH_TECHNICAL_ERROR], $result['errors']);
         $this->assertSame(['identifier' => 'john@example.com'], $result['old']);
+    }
+
+    public function testLoginSuccessWithRememberMeReturnsRememberMeToken(): void
+    {
+        $form = [
+            'identifier'  => 'john@example.com',
+            'password'    => 'Password123!',
+            'remember_me' => '1',
+        ];
+
+        $user = new UserEntity();
+        $user->setUserId(42);
+        $user->setPassword(password_hash('Password123!', PASSWORD_ARGON2I));
+        $user->setStatus('active');
+
+        $this->validator->method('validateLogin')->willReturn([]);
+
+        $this->userModel
+            ->expects($this->once())
+            ->method('findAuthByEmail')
+            ->with('john@example.com')
+            ->willReturn($user);
+
+        $this->session
+            ->expects($this->once())
+            ->method('regenerateAndDeleteOld');
+
+        $this->session
+            ->expects($this->once())
+            ->method('set')
+            ->with('user', [
+                'id'    => 42,
+                'roles' => ['USER'],
+            ]);
+
+        $this->rememberMeService
+            ->expects($this->once())
+            ->method('createRememberMeToken')
+            ->with(42)
+            ->willReturn('raw-token');
+
+        $result = $this->service->login($form);
+
+        $this->assertSame([
+            'ok'                => true,
+            'remember_me_token' => 'raw-token',
+        ], $result);
+    }
+
+    public function testLoginSuccessWithRememberMeOnReturnsRememberMeToken(): void
+    {
+        $form = [
+            'identifier'  => 'john@example.com',
+            'password'    => 'Password123!',
+            'remember_me' => 'on',
+        ];
+
+        $user = new UserEntity();
+        $user->setUserId(42);
+        $user->setPassword(password_hash('Password123!', PASSWORD_ARGON2I));
+        $user->setStatus('active');
+
+        $this->validator->method('validateLogin')->willReturn([]);
+
+        $this->userModel
+            ->expects($this->once())
+            ->method('findAuthByEmail')
+            ->with('john@example.com')
+            ->willReturn($user);
+
+        $this->session
+            ->expects($this->once())
+            ->method('regenerateAndDeleteOld');
+
+        $this->session
+            ->expects($this->once())
+            ->method('set')
+            ->with('user', [
+                'id'    => 42,
+                'roles' => ['USER'],
+            ]);
+
+        $this->rememberMeService
+            ->expects($this->once())
+            ->method('createRememberMeToken')
+            ->with(42)
+            ->willReturn('raw-token');
+
+        $result = $this->service->login($form);
+
+        $this->assertSame([
+            'ok'                => true,
+            'remember_me_token' => 'raw-token',
+        ], $result);
+    }
+
+    public function testLoginSuccessWithRememberMeReturnsOkWhenTokenCreationFails(): void
+    {
+        $form = [
+            'identifier'  => 'john@example.com',
+            'password'    => 'Password123!',
+            'remember_me' => '1',
+        ];
+
+        $user = new UserEntity();
+        $user->setUserId(42);
+        $user->setPassword(password_hash('Password123!', PASSWORD_ARGON2I));
+        $user->setStatus('active');
+
+        $this->validator->method('validateLogin')->willReturn([]);
+
+        $this->userModel
+            ->expects($this->once())
+            ->method('findAuthByEmail')
+            ->with('john@example.com')
+            ->willReturn($user);
+
+        $this->session
+            ->expects($this->once())
+            ->method('regenerateAndDeleteOld');
+
+        $this->session
+            ->expects($this->once())
+            ->method('set')
+            ->with('user', [
+                'id'    => 42,
+                'roles' => ['USER'],
+            ]);
+
+        $this->rememberMeService
+            ->expects($this->once())
+            ->method('createRememberMeToken')
+            ->with(42)
+            ->willReturn(null);
+
+        $result = $this->service->login($form);
+
+        $this->assertSame(['ok' => true], $result);
     }
 }

--- a/tests/Unit/Service/Security/LogoutServiceTest.php
+++ b/tests/Unit/Service/Security/LogoutServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Service\Security;
 
 use App\Core\Contract\SessionInterface;
+use App\Service\Security\Contract\RememberMeServiceInterface;
 use App\Service\Security\LogoutService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -13,14 +14,19 @@ final class LogoutServiceTest extends TestCase
 {
     private SessionInterface&MockObject $session;
     private LogoutService $service;
+    private RememberMeServiceInterface&MockObject $rememberMeService;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->session = $this->createMock(SessionInterface::class);
+        $this->session           = $this->createMock(SessionInterface::class);
+        $this->rememberMeService = $this->createMock(RememberMeServiceInterface::class);
 
-        $this->service = new LogoutService($this->session);
+        $this->service = new LogoutService(
+            $this->session,
+            $this->rememberMeService,
+        );
     }
 
     public function testLogoutClearsSessionAndRegeneratesIdWhenUserIdIsInt(): void
@@ -28,8 +34,11 @@ final class LogoutServiceTest extends TestCase
         $this->session
             ->expects($this->once())
             ->method('get')
-            ->with('user_id')
-            ->willReturn(223);
+            ->with('user')
+            ->willReturn([
+                'id'    => 223,
+                'roles' => ['USER'],
+            ]);
 
         $this->session
             ->expects($this->once())
@@ -38,19 +47,28 @@ final class LogoutServiceTest extends TestCase
         $this->session
             ->expects($this->once())
             ->method('regenerateAndDeleteOld');
+
+        $this->rememberMeService
+            ->expects($this->once())
+            ->method('invalidateRememberMeForUser')
+            ->with(223)
+            ->willReturn(true);
 
         $this->service->logout();
 
         $this->assertTrue(true);
     }
 
-    public function testLogoutClearsSessionAndRegeneratesIdWhenUserIdIsString(): void
+    public function testLogoutDoesNotInvalidateRememberMeWhenUserIdIsString(): void
     {
         $this->session
             ->expects($this->once())
             ->method('get')
-            ->with('user_id')
-            ->willReturn('223');
+            ->with('user')
+            ->willReturn([
+                'id'    => '223',
+                'roles' => ['user'],
+            ]);
 
         $this->session
             ->expects($this->once())
@@ -59,6 +77,10 @@ final class LogoutServiceTest extends TestCase
         $this->session
             ->expects($this->once())
             ->method('regenerateAndDeleteOld');
+
+        $this->rememberMeService
+            ->expects($this->never())
+            ->method('invalidateRememberMeForUser');
 
         $this->service->logout();
 
@@ -70,7 +92,7 @@ final class LogoutServiceTest extends TestCase
         $this->session
             ->expects($this->once())
             ->method('get')
-            ->with('user_id')
+            ->with('user')
             ->willReturn(null);
 
         $this->session
@@ -80,6 +102,10 @@ final class LogoutServiceTest extends TestCase
         $this->session
             ->expects($this->once())
             ->method('regenerateAndDeleteOld');
+
+        $this->rememberMeService
+            ->expects($this->never())
+            ->method('invalidateRememberMeForUser');
 
         $this->service->logout();
 
@@ -91,7 +117,7 @@ final class LogoutServiceTest extends TestCase
         $this->session
             ->expects($this->once())
             ->method('get')
-            ->with('user_id')
+            ->with('user')
             ->willReturn(['unexpected']);
 
         $this->session
@@ -101,6 +127,10 @@ final class LogoutServiceTest extends TestCase
         $this->session
             ->expects($this->once())
             ->method('regenerateAndDeleteOld');
+
+        $this->rememberMeService
+            ->expects($this->never())
+            ->method('invalidateRememberMeForUser');
 
         $this->service->logout();
 

--- a/tests/Unit/Service/Security/RememberMeServiceTest.php
+++ b/tests/Unit/Service/Security/RememberMeServiceTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Service\Security;
+
+use App\Core\Contract\SessionInterface;
+use App\Model\Contract\UserTokenModelInterface;
+use App\Security\Contract\TokenGeneratorInterface;
+use App\Service\Security\RememberMeService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class RememberMeServiceTest extends TestCase
+{
+    private UserTokenModelInterface&MockObject $userTokenModel;
+    private TokenGeneratorInterface&MockObject $tokenGenerator;
+    private SessionInterface&MockObject $session;
+
+    private RememberMeService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userTokenModel = $this->createMock(UserTokenModelInterface::class);
+        $this->tokenGenerator = $this->createMock(TokenGeneratorInterface::class);
+        $this->session        = $this->createMock(SessionInterface::class);
+
+        $this->service = new RememberMeService(
+            $this->userTokenModel,
+            $this->tokenGenerator,
+            $this->session,
+        );
+    }
+
+    public function testCreateRememberMeTokenReturnsNullWhenUserIdIsInvalid(): void
+    {
+        $this->tokenGenerator
+            ->expects($this->never())
+            ->method('generateUrlSafeToken');
+
+        $this->userTokenModel
+            ->expects($this->never())
+            ->method('createRememberMeToken');
+
+        $this->assertNull($this->service->createRememberMeToken(0));
+    }
+
+    public function testCreateRememberMeTokenReturnsRawTokenWhenPersisted(): void
+    {
+        $this->tokenGenerator
+            ->expects($this->once())
+            ->method('generateUrlSafeToken')
+            ->willReturn('raw-token');
+
+        $this->tokenGenerator
+            ->expects($this->once())
+            ->method('hashToken')
+            ->with('raw-token')
+            ->willReturn(str_repeat('a', 32));
+
+        $this->userTokenModel
+            ->expects($this->once())
+            ->method('createRememberMeToken')
+            ->with(
+                42,
+                str_repeat('a', 32),
+                $this->isInstanceOf(\DateTimeImmutable::class)
+            )
+            ->willReturn(true);
+
+        $this->assertSame('raw-token', $this->service->createRememberMeToken(42));
+    }
+
+    public function testCreateRememberMeTokenReturnsNullWhenPersistenceFails(): void
+    {
+        $this->tokenGenerator
+            ->method('generateUrlSafeToken')
+            ->willReturn('raw-token');
+
+        $this->tokenGenerator
+            ->method('hashToken')
+            ->willReturn(str_repeat('b', 32));
+
+        $this->userTokenModel
+            ->expects($this->once())
+            ->method('createRememberMeToken')
+            ->willReturn(false);
+
+        $this->assertNull($this->service->createRememberMeToken(42));
+    }
+
+    public function testCreateRememberMeTokenReturnsNullOnThrowable(): void
+    {
+        $this->tokenGenerator
+            ->expects($this->once())
+            ->method('generateUrlSafeToken')
+            ->willThrowException(new \RuntimeException('token failure'));
+
+        $this->assertNull($this->service->createRememberMeToken(42));
+    }
+
+    public function testRestoreSessionFromTokenReturnsFalseWhenTokenIsEmpty(): void
+    {
+        $this->tokenGenerator
+            ->expects($this->never())
+            ->method('hashToken');
+
+        $this->assertFalse($this->service->restoreSessionFromToken('   '));
+    }
+
+    public function testRestoreSessionFromTokenReturnsFalseWhenTokenNotFound(): void
+    {
+        $this->tokenGenerator
+            ->expects($this->once())
+            ->method('hashToken')
+            ->with('raw-token')
+            ->willReturn(str_repeat('c', 32));
+
+        $this->userTokenModel
+            ->expects($this->once())
+            ->method('findRememberMeContextByHash')
+            ->with(str_repeat('c', 32))
+            ->willReturn(null);
+
+        $this->session
+            ->expects($this->never())
+            ->method('set');
+
+        $this->assertFalse($this->service->restoreSessionFromToken('raw-token'));
+    }
+
+    public function testRestoreSessionFromTokenReturnsFalseWhenUserIdIsMissing(): void
+    {
+        $this->tokenGenerator
+            ->method('hashToken')
+            ->willReturn(str_repeat('d', 32));
+
+        $this->userTokenModel
+            ->method('findRememberMeContextByHash')
+            ->willReturn([
+                'user_id'     => null,
+                'user_status' => 'active',
+                'used'        => 0,
+                'is_expired'  => 0,
+            ]);
+
+        $this->session
+            ->expects($this->never())
+            ->method('set');
+
+        $this->assertFalse($this->service->restoreSessionFromToken('raw-token'));
+    }
+
+    public function testRestoreSessionFromTokenReturnsFalseWhenTokenIsUsed(): void
+    {
+        $this->tokenGenerator
+            ->method('hashToken')
+            ->willReturn(str_repeat('e', 32));
+
+        $this->userTokenModel
+            ->method('findRememberMeContextByHash')
+            ->willReturn([
+                'user_id'     => 42,
+                'user_status' => 'active',
+                'used'        => 1,
+                'is_expired'  => 0,
+            ]);
+
+        $this->session
+            ->expects($this->never())
+            ->method('set');
+
+        $this->assertFalse($this->service->restoreSessionFromToken('raw-token'));
+    }
+
+    public function testRestoreSessionFromTokenInvalidatesAndReturnsFalseWhenTokenIsExpired(): void
+    {
+        $this->tokenGenerator
+            ->method('hashToken')
+            ->willReturn(str_repeat('f', 32));
+
+        $this->userTokenModel
+            ->method('findRememberMeContextByHash')
+            ->willReturn([
+                'user_id'     => 42,
+                'user_status' => 'active',
+                'used'        => 0,
+                'is_expired'  => 1,
+            ]);
+
+        $this->userTokenModel
+            ->expects($this->once())
+            ->method('invalidateRememberMeToken')
+            ->with(42)
+            ->willReturn(true);
+
+        $this->session
+            ->expects($this->never())
+            ->method('set');
+
+        $this->assertFalse($this->service->restoreSessionFromToken('raw-token'));
+    }
+
+    public function testRestoreSessionFromTokenInvalidatesAndReturnsFalseWhenUserIsNotActive(): void
+    {
+        $this->tokenGenerator
+            ->method('hashToken')
+            ->willReturn(str_repeat('g', 32));
+
+        $this->userTokenModel
+            ->method('findRememberMeContextByHash')
+            ->willReturn([
+                'user_id'     => 42,
+                'user_status' => 'inactive',
+                'used'        => 0,
+                'is_expired'  => 0,
+            ]);
+
+        $this->userTokenModel
+            ->expects($this->once())
+            ->method('invalidateRememberMeToken')
+            ->with(42)
+            ->willReturn(true);
+
+        $this->session
+            ->expects($this->never())
+            ->method('set');
+
+        $this->assertFalse($this->service->restoreSessionFromToken('raw-token'));
+    }
+
+    public function testRestoreSessionFromTokenCreatesSessionAndReturnsTrueWhenTokenIsValid(): void
+    {
+        $this->tokenGenerator
+            ->expects($this->once())
+            ->method('hashToken')
+            ->with('raw-token')
+            ->willReturn(str_repeat('h', 32));
+
+        $this->userTokenModel
+            ->expects($this->once())
+            ->method('findRememberMeContextByHash')
+            ->with(str_repeat('h', 32))
+            ->willReturn([
+                'user_id'     => 42,
+                'user_status' => 'active',
+                'used'        => 0,
+                'is_expired'  => 0,
+            ]);
+
+        $this->session
+            ->expects($this->once())
+            ->method('regenerateAndDeleteOld');
+
+        $this->session
+            ->expects($this->once())
+            ->method('set')
+            ->with('user', [
+                'id'    => 42,
+                'roles' => ['USER'],
+            ]);
+
+        $this->assertTrue($this->service->restoreSessionFromToken('raw-token'));
+    }
+
+    public function testRestoreSessionFromTokenReturnsFalseOnThrowable(): void
+    {
+        $this->tokenGenerator
+            ->expects($this->once())
+            ->method('hashToken')
+            ->willThrowException(new \RuntimeException('hash failure'));
+
+        $this->session
+            ->expects($this->never())
+            ->method('set');
+
+        $this->assertFalse($this->service->restoreSessionFromToken('raw-token'));
+    }
+
+    public function testInvalidateRememberMeForUserReturnsFalseWhenUserIdIsInvalid(): void
+    {
+        $this->userTokenModel
+            ->expects($this->never())
+            ->method('invalidateRememberMeToken');
+
+        $this->assertFalse($this->service->invalidateRememberMeForUser(0));
+    }
+
+    public function testInvalidateRememberMeForUserReturnsModelResult(): void
+    {
+        $this->userTokenModel
+            ->expects($this->once())
+            ->method('invalidateRememberMeToken')
+            ->with(42)
+            ->willReturn(true);
+
+        $this->assertTrue($this->service->invalidateRememberMeForUser(42));
+    }
+
+    public function testInvalidateRememberMeForUserReturnsFalseOnThrowable(): void
+    {
+        $this->userTokenModel
+            ->expects($this->once())
+            ->method('invalidateRememberMeToken')
+            ->with(42)
+            ->willThrowException(new \RuntimeException('db failure'));
+
+        $this->assertFalse($this->service->invalidateRememberMeForUser(42));
+    }
+}

--- a/tests/Unit/Validation/FormValidatorTest.php
+++ b/tests/Unit/Validation/FormValidatorTest.php
@@ -215,4 +215,46 @@ final class FormValidatorTest extends TestCase
 
         $this->assertSame([], $errors);
     }
+
+    // ---------------- validateLogin() ----------------
+
+    public function test_validateLogin_returns_required_errors_when_identifier_and_password_are_empty(): void
+    {
+        $errors = $this->v->validateLogin([
+        'identifier' => '',
+        'password'   => '',
+        ]);
+
+        $this->assertSame([
+        ErrorCode::AUTH_FIELD_REQUIRED,
+        ErrorCode::AUTH_FIELD_REQUIRED,
+        ], $errors);
+    }
+
+    public function test_validateLogin_returns_empty_array_when_identifier_and_password_are_present(): void
+    {
+        $errors = $this->v->validateLogin([
+        'identifier' => 'john@example.test',
+        'password'   => 'secret',
+        ]);
+
+        $this->assertSame([], $errors);
+    }
+
+    // ---------------- validatePasswordField() ----------------
+
+    public function test_validatePasswordField_returns_error_when_password_is_invalid(): void
+    {
+        $this->assertSame(
+            ErrorCode::AUTH_PASSWORD_INVALID,
+            $this->v->validatePasswordField('weak')
+        );
+    }
+
+    public function test_validatePasswordField_returns_null_when_password_is_valid(): void
+    {
+        $this->assertNull(
+            $this->v->validatePasswordField('Aa1!Bb2@Cc3#')
+        );
+    }
 }


### PR DESCRIPTION
## What does this pull request do?

- [x] Adds a feature
- [ ] Fixes a bug
- [ ] Refactors existing code
- [ ] Other (describe):

## Description

This pull request implements a secure "Remember me" authentication system fully integrated with the existing session-based login flow.

Main changes include:

- added remember me option in login flow
- generation of secure random persistent tokens
- hashed token storage in `user_token` table using `remember_me` purpose
- secure HTTP-only cookie management with expiration handling
- automatic session restoration through dedicated middleware
- invalid, expired, used, and inactive-user token handling
- remember me token invalidation on logout
- compatibility preserved with existing authentication behavior when remember me is not selected

Additional work completed:

- PHPUnit tests added and updated for all related services, middleware, handlers, models, and validators
- PHPStan issues fixed
- PHPMD issues fixed
- code quality and coverage validated successfully

This implementation preserves the existing security architecture and avoids storing raw tokens in database storage.

## Related issue

Closes #25 

## Checklist

- [x] Code runs without error
- [x] Tests added or updated
- [x] Coding style respected
- [x] Issue linked (if applicable)
